### PR TITLE
Fix race condition on metrics creation

### DIFF
--- a/src/Prometheus.Client/Collectors/CollectorRegistry.cs
+++ b/src/Prometheus.Client/Collectors/CollectorRegistry.cs
@@ -212,14 +212,14 @@ namespace Prometheus.Client.Collectors
             {
                 collectors = new ICollector[_collectors.Count];
                 _collectors.Values.CopyTo(collectors, 0);
+
+                Array.Sort(collectors, (a, b) => string.Compare(a.Configuration.Name, b.Configuration.Name, StringComparison.OrdinalIgnoreCase));
+                return collectors;
             }
             finally
             {
                 _lock.ExitReadLock();
             }
-
-            Array.Sort(collectors, (a, b) => string.Compare(a.Configuration.Name, b.Configuration.Name, StringComparison.OrdinalIgnoreCase));
-            return collectors;
         }
     }
 }

--- a/tests/Prometheus.Client.Tests/Mocks/DummyCollector.cs
+++ b/tests/Prometheus.Client.Tests/Mocks/DummyCollector.cs
@@ -16,7 +16,6 @@ namespace Prometheus.Client.Tests.Mocks
         public IReadOnlyList<string> MetricNames { get; }
         public void Collect(IMetricsWriter writer)
         {
-            throw new System.NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Fix race condition on multiple threads creating a metrics while scrape is active on another thread.

Possible root cause for https://github.com/prom-client-net/prom-client-dependencyinjection/issues/20