### PR TITLE
Prometheus labels can be empty

### DIFF
--- a/src/Prometheus.Client/LabelsHelper.cs
+++ b/src/Prometheus.Client/LabelsHelper.cs
@@ -80,7 +80,7 @@ namespace Prometheus.Client
             for (var i = 0; i < values.Count; i++)
             {
                 var val = values[i];
-                if(string.IsNullOrEmpty(val))
+                if(val == null)
                     throw new ArgumentException("Label value cannot be empty");
 
                 result = HashCombine(result, val.GetHashCode());

--- a/src/Prometheus.Client/LabelsHelper.cs
+++ b/src/Prometheus.Client/LabelsHelper.cs
@@ -264,7 +264,7 @@ namespace Prometheus.Client
             {
                 return HashCodeReducer(values, 0, (item, _, aggregated) =>
                 {
-                    if(string.IsNullOrEmpty(item))
+                    if(item == null)
                         throw new ArgumentException("Label value cannot be empty");
                     return HashCombine(aggregated, item.GetHashCode());
                 });

--- a/tests/Prometheus.Client.Tests/LabelsHelperTests.cs
+++ b/tests/Prometheus.Client.Tests/LabelsHelperTests.cs
@@ -216,9 +216,18 @@ namespace Prometheus.Client.Tests
         }
 
         [Fact]
-        public void LabelEmpty()
+        public void LabelCanBeEmpty()
         {
+            // Doesn't throw exception
             LabelsHelper.GetHashCode(new string[] { "a", "" });
+            LabelsHelper.GetHashCode(ValueTuple.Create("a", ""));
+        }
+
+        [Fact]
+        public void LabelCannotBeNull()
+        {
+            Assert.Throws<ArgumentException>(() => LabelsHelper.GetHashCode(new string[] {"a", null}));
+            Assert.Throws<ArgumentException>(() => LabelsHelper.GetHashCode(ValueTuple.Create<string, string>("a", null)));
         }
 
         [Fact]

--- a/tests/Prometheus.Client.Tests/LabelsHelperTests.cs
+++ b/tests/Prometheus.Client.Tests/LabelsHelperTests.cs
@@ -216,6 +216,12 @@ namespace Prometheus.Client.Tests
         }
 
         [Fact]
+        public void LabelEmpty()
+        {
+            LabelsHelper.GetHashCode(new string[] { "a", "" });
+        }
+
+        [Fact]
         public void GetHashCode0()
         {
             var tupleCode = LabelsHelper.GetHashCode(ValueTuple.Create());


### PR DESCRIPTION
Prometheus allows empty labels. It is perfectly possible and makes sense in many scenarios. However, prom-client library doesn't allow empty string as label. This pull request fixes it. Null value is still not allowed.