### PR TITLE
Normalize default metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Thanks for those who are supporting us via [GitHub Sponsors](https://github.com/
 
 <table>
    <tr>
-      <td style="text-align: center"><a href="https://github.com/promitor"><img src="https://avatars.githubusercontent.com/u/53140212?s=200&v=4" width="100px;" alt=""/><br /><sub><b>Promitor</b></sub></a><br /></td>
+      <td align="center"><a href="https://github.com/promitor"><img src="https://avatars.githubusercontent.com/u/53140212?s=200&v=4" width="100px;" alt=""/><br /><sub><b>Promitor</b></sub></a><br /></td>
    </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 [![NuGet](https://img.shields.io/nuget/v/Prometheus.Client.svg)](https://www.nuget.org/packages/Prometheus.Client)
 [![NuGet](https://img.shields.io/nuget/dt/Prometheus.Client.svg)](https://www.nuget.org/packages/Prometheus.Client)
-[![License MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-
 [![CodeFactor](https://www.codefactor.io/repository/github/prom-client-net/prom-client/badge)](https://www.codefactor.io/repository/github/prom-client-net/prom-client)
 [![CI](https://img.shields.io/github/workflow/status/prom-client-net/prom-client/%F0%9F%92%BF%20CI%20Master?label=CI&logo=github)](https://github.com/prom-client-net/prom-client/actions/workflows/master.yml)
 [![codecov](https://codecov.io/gh/prom-client-net/prom-client/branch/master/graph/badge.svg)](https://codecov.io/gh/prom-client-net/prom-client)
+[![License MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 .NET Client library for [prometheus.io](https://prometheus.io/)  
 
@@ -23,7 +22,7 @@ Find more details on [benchmarks description](/docs/benchmarks/GeneralUseCase.md
 
 ## Installation
 
-```shell script
+```sh
 dotnet add package Prometheus.Client
 ```
 
@@ -128,7 +127,7 @@ summary.Observe(5.3);
 ### Histogram
 
 Histograms track the size and number of events in buckets.
-This allows for aggregatable calculation of quantiles.
+This allows for aggregate calculation of quantiles.
 
 ```c#
 var hist = metricFactory.CreateHistogram("my_histogram", "help text", buckets: new[] { 0, 0.2, 0.4, 0.6, 0.8, 0.9 });
@@ -165,25 +164,25 @@ counter.WithLabels(("POST", "/cancel")).Inc();
 
 AspNetCore Middleware: [Prometheus.Client.AspNetCore](https://github.com/prom-client-net/prom-client-aspnetcore)
 
-```shell script
+```sh
 dotnet add package Prometheus.Client.AspNetCore
 ```
 
 Standalone host: [Prometheus.Client.MetricServer](https://github.com/prom-client-net/prom-client-metricserver)
 
-```shell script
+```sh
 dotnet add package Prometheus.Client.MetricServer
 ```
 
 Push metrics to a PushGateway: [Prometheus.Client.MetricPusher](https://github.com/prom-client-net/prom-client-metricpusher)
 
-```shell script
+```sh
 dotnet add package Prometheus.Client.MetricPusher
 ```
 
 Collect http requests duration: [Prometheus.Client.HttpRequestDurations](https://github.com/prom-client-net/prom-client-httprequestdurations)
 
-```shell script
+```sh
 dotnet add package Prometheus.Client.HttpRequestDurations
 ```
 
@@ -200,8 +199,7 @@ Thanks for those who are supporting us via [GitHub Sponsors](https://github.com/
 
 <table>
    <tr>
-      <td align="center"><a href="https://github.com/tomkerkhove"><img src="https://avatars.githubusercontent.com/u/4345663?v=4" width="100px;" alt=""/><br /><sub><b>Tom Kerkhove</b></sub></a><br /></td>
-      <td align="center"><a href="https://github.com/promitor"><img src="https://avatars.githubusercontent.com/u/53140212?s=200&v=4" width="100px;" alt=""/><br /><sub><b>Promitor</b></sub></a><br /></td>
+      <td style="text-align: center"><a href="https://github.com/promitor"><img src="https://avatars.githubusercontent.com/u/53140212?s=200&v=4" width="100px;" alt=""/><br /><sub><b>Promitor</b></sub></a><br /></td>
    </tr>
 </table>
 

--- a/src/Prometheus.Client/Collectors/DefaultCollectors.cs
+++ b/src/Prometheus.Client/Collectors/DefaultCollectors.cs
@@ -1,3 +1,4 @@
+using System;
 using Prometheus.Client.Collectors.DotNetStats;
 using Prometheus.Client.Collectors.ProcessStats;
 
@@ -7,13 +8,28 @@ namespace Prometheus.Client.Collectors
     {
         public static ICollectorRegistry UseDefaultCollectors(this ICollectorRegistry registry)
         {
-            return UseDefaultCollectors(registry, "");
+            return UseDefaultCollectors(registry, string.Empty);
         }
 
         public static ICollectorRegistry UseDefaultCollectors(this ICollectorRegistry registry, string prefixName)
         {
             registry.UseDotNetStats(prefixName);
             registry.UseProcessStats(prefixName);
+
+            return registry;
+        }
+
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public static ICollectorRegistry UseDefaultCollectors(this ICollectorRegistry registry, bool addLegacyMetrics)
+        {
+            return UseDefaultCollectors(registry, string.Empty, addLegacyMetrics);
+        }
+
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public static ICollectorRegistry UseDefaultCollectors(this ICollectorRegistry registry, string prefixName, bool addLegacyMetrics)
+        {
+            registry.UseDotNetStats(prefixName, addLegacyMetrics);
+            registry.UseProcessStats(prefixName, addLegacyMetrics);
 
             return registry;
         }

--- a/src/Prometheus.Client/Collectors/DotNetStats/CollectorRegistryExtensions.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/CollectorRegistryExtensions.cs
@@ -16,17 +16,17 @@ namespace Prometheus.Client.Collectors.DotNetStats
             return registry;
         }
 
-        [Obsolete("'addLegacyMetricNames' will be removed in future versions")]
-        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, bool addLegacyMetricNames)
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, bool addLegacyMetrics)
         {
-            return UseDotNetStats(registry, string.Empty, addLegacyMetricNames);
+            return UseDotNetStats(registry, string.Empty, addLegacyMetrics);
         }
 
-        [Obsolete("'addLegacyMetricNames' will be removed in future versions")]
-        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, string prefixName, bool addLegacyMetricNames)
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, string prefixName, bool addLegacyMetrics)
         {
             registry.Add(new GCCollectionCountCollector(prefixName));
-            registry.Add(new GCTotalMemoryCollector(prefixName, addLegacyMetricNames));
+            registry.Add(new GCTotalMemoryCollector(prefixName, addLegacyMetrics));
 
             return registry;
         }

--- a/src/Prometheus.Client/Collectors/DotNetStats/CollectorRegistryExtensions.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/CollectorRegistryExtensions.cs
@@ -2,15 +2,15 @@ namespace Prometheus.Client.Collectors.DotNetStats
 {
     public static class CollectorRegistryExtensions
     {
-        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry)
+        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, bool addLegacyMetricNames = false)
         {
-            return UseDotNetStats(registry, "");
+            return UseDotNetStats(registry, string.Empty, addLegacyMetricNames);
         }
 
-        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, string prefixName)
+        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, string prefixName, bool addLegacyMetricNames = false)
         {
             registry.Add(new GCCollectionCountCollector(prefixName));
-            registry.Add(new GCTotalMemoryCollector(prefixName));
+            registry.Add(new GCTotalMemoryCollector(prefixName, addLegacyMetricNames));
 
             return registry;
         }

--- a/src/Prometheus.Client/Collectors/DotNetStats/CollectorRegistryExtensions.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/CollectorRegistryExtensions.cs
@@ -8,6 +8,7 @@ namespace Prometheus.Client.Collectors.DotNetStats
         {
             return UseDotNetStats(registry, string.Empty);
         }
+
         public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, string prefixName)
         {
             registry.Add(new GCCollectionCountCollector(prefixName));

--- a/src/Prometheus.Client/Collectors/DotNetStats/CollectorRegistryExtensions.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/CollectorRegistryExtensions.cs
@@ -1,13 +1,29 @@
+using System;
+
 namespace Prometheus.Client.Collectors.DotNetStats
 {
     public static class CollectorRegistryExtensions
     {
-        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, bool addLegacyMetricNames = false)
+        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry)
+        {
+            return UseDotNetStats(registry, string.Empty);
+        }
+        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, string prefixName)
+        {
+            registry.Add(new GCCollectionCountCollector(prefixName));
+            registry.Add(new GCTotalMemoryCollector(prefixName));
+
+            return registry;
+        }
+
+        [Obsolete("'addLegacyMetricNames' will be removed in future versions")]
+        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, bool addLegacyMetricNames)
         {
             return UseDotNetStats(registry, string.Empty, addLegacyMetricNames);
         }
 
-        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, string prefixName, bool addLegacyMetricNames = false)
+        [Obsolete("'addLegacyMetricNames' will be removed in future versions")]
+        public static ICollectorRegistry UseDotNetStats(this ICollectorRegistry registry, string prefixName, bool addLegacyMetricNames)
         {
             registry.Add(new GCCollectionCountCollector(prefixName));
             registry.Add(new GCTotalMemoryCollector(prefixName, addLegacyMetricNames));

--- a/src/Prometheus.Client/Collectors/DotNetStats/GCCollectionCountCollector.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/GCCollectionCountCollector.cs
@@ -11,7 +11,7 @@ namespace Prometheus.Client.Collectors.DotNetStats
         private readonly string[] _genNames;
 
         public GCCollectionCountCollector()
-            : this("")
+            : this(string.Empty)
         {
         }
 

--- a/src/Prometheus.Client/Collectors/DotNetStats/GCCollectionCountCollector.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/GCCollectionCountCollector.cs
@@ -10,6 +10,10 @@ namespace Prometheus.Client.Collectors.DotNetStats
         private readonly string _name;
         private readonly string[] _genNames;
 
+        public CollectorConfiguration Configuration { get; }
+
+        public IReadOnlyList<string> MetricNames { get; }
+
         public GCCollectionCountCollector()
             : this(string.Empty)
         {
@@ -24,10 +28,6 @@ namespace Prometheus.Client.Collectors.DotNetStats
             for (var gen = 0; gen <= GC.MaxGeneration; gen++)
                 _genNames[gen] = gen.ToString();
         }
-
-        public CollectorConfiguration Configuration { get; }
-
-        public IReadOnlyList<string> MetricNames { get; }
 
         public void Collect(IMetricsWriter writer)
         {

--- a/src/Prometheus.Client/Collectors/DotNetStats/GCTotalMemoryCollector.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/GCTotalMemoryCollector.cs
@@ -11,8 +11,8 @@ namespace Prometheus.Client.Collectors.DotNetStats
         private readonly string _legacyName;
         private readonly bool _addLegacyMetricNames;
 
-        public GCTotalMemoryCollector()
-            : this(string.Empty)
+        public GCTotalMemoryCollector(bool addLegacyMetricNames = false)
+            : this(string.Empty, addLegacyMetricNames)
         {
         }
 

--- a/src/Prometheus.Client/Collectors/DotNetStats/GCTotalMemoryCollector.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/GCTotalMemoryCollector.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using Prometheus.Client.MetricsWriter;
 
+#pragma warning disable CS0618
+
 namespace Prometheus.Client.Collectors.DotNetStats
 {
     public class GCTotalMemoryCollector : ICollector
@@ -11,12 +13,24 @@ namespace Prometheus.Client.Collectors.DotNetStats
         private readonly string _legacyName;
         private readonly bool _addLegacyMetricNames;
 
-        public GCTotalMemoryCollector(bool addLegacyMetricNames = false)
+        public GCTotalMemoryCollector()
+            : this(string.Empty)
+        {
+        }
+
+        public GCTotalMemoryCollector(string prefixName)
+            : this(prefixName, false)
+        {
+        }
+
+        [Obsolete("'addLegacyMetricNames' will be removed in future versions")]
+        public GCTotalMemoryCollector(bool addLegacyMetricNames)
             : this(string.Empty, addLegacyMetricNames)
         {
         }
 
-        public GCTotalMemoryCollector(string prefixName, bool addLegacyMetricNames = false)
+        [Obsolete("'addLegacyMetricNames' will be removed in future versions")]
+        public GCTotalMemoryCollector(string prefixName, bool addLegacyMetricNames)
         {
             _legacyName = prefixName + "dotnet_totalmemory";
             _name = prefixName + "dotnet_total_memory_bytes";

--- a/src/Prometheus.Client/Collectors/DotNetStats/GCTotalMemoryCollector.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/GCTotalMemoryCollector.cs
@@ -6,17 +6,17 @@ namespace Prometheus.Client.Collectors.DotNetStats
 {
     public class GCTotalMemoryCollector : ICollector
     {
-        private const string _help = "Total known allocated memory";
+        private const string _help = "Total known allocated memory in bytes";
         private readonly string _name;
 
         public GCTotalMemoryCollector()
-            : this("")
+            : this(string.Empty)
         {
         }
 
         public GCTotalMemoryCollector(string prefixName)
         {
-            _name = prefixName + "dotnet_totalmemory";
+            _name = prefixName + "dotnet_total_memory_bytes";
             Configuration = new CollectorConfiguration(nameof(GCTotalMemoryCollector));
             MetricNames = new[] { _name };
         }

--- a/src/Prometheus.Client/Collectors/DotNetStats/GCTotalMemoryCollector.cs
+++ b/src/Prometheus.Client/Collectors/DotNetStats/GCTotalMemoryCollector.cs
@@ -11,7 +11,10 @@ namespace Prometheus.Client.Collectors.DotNetStats
         private const string _help = "Total known allocated memory in bytes";
         private readonly string _name;
         private readonly string _legacyName;
-        private readonly bool _addLegacyMetricNames;
+        private readonly bool _addLegacyMetrics;
+
+        public CollectorConfiguration Configuration { get; }
+        public IReadOnlyList<string> MetricNames { get; }
 
         public GCTotalMemoryCollector()
             : this(string.Empty)
@@ -23,26 +26,23 @@ namespace Prometheus.Client.Collectors.DotNetStats
         {
         }
 
-        [Obsolete("'addLegacyMetricNames' will be removed in future versions")]
-        public GCTotalMemoryCollector(bool addLegacyMetricNames)
-            : this(string.Empty, addLegacyMetricNames)
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public GCTotalMemoryCollector(bool addLegacyMetrics)
+            : this(string.Empty, addLegacyMetrics)
         {
         }
 
-        [Obsolete("'addLegacyMetricNames' will be removed in future versions")]
-        public GCTotalMemoryCollector(string prefixName, bool addLegacyMetricNames)
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public GCTotalMemoryCollector(string prefixName, bool addLegacyMetrics)
         {
             _legacyName = prefixName + "dotnet_totalmemory";
             _name = prefixName + "dotnet_total_memory_bytes";
 
-            _addLegacyMetricNames = addLegacyMetricNames;
+            _addLegacyMetrics = addLegacyMetrics;
 
             Configuration = new CollectorConfiguration(nameof(GCTotalMemoryCollector));
-            MetricNames = _addLegacyMetricNames ? new[] { _legacyName, _name } : new[] { _name };
+            MetricNames = _addLegacyMetrics ? new[] { _legacyName, _name } : new[] { _name };
         }
-
-        public CollectorConfiguration Configuration { get; }
-        public IReadOnlyList<string> MetricNames { get; }
 
         public void Collect(IMetricsWriter writer)
         {
@@ -50,7 +50,7 @@ namespace Prometheus.Client.Collectors.DotNetStats
             writer.WriteSample(GC.GetTotalMemory(false));
             writer.EndMetric();
 
-            if (_addLegacyMetricNames)
+            if (_addLegacyMetrics)
             {
                 writer.WriteMetricHeader(_legacyName, MetricType.Gauge, _help);
                 writer.WriteSample(GC.GetTotalMemory(false));

--- a/src/Prometheus.Client/Collectors/ProcessStats/CollectorRegistryExtensions.cs
+++ b/src/Prometheus.Client/Collectors/ProcessStats/CollectorRegistryExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 
 namespace Prometheus.Client.Collectors.ProcessStats
@@ -12,6 +13,20 @@ namespace Prometheus.Client.Collectors.ProcessStats
         public static ICollectorRegistry UseProcessStats(this ICollectorRegistry registry, string prefixName)
         {
             registry.Add(new ProcessCollector(Process.GetCurrentProcess(), prefixName));
+
+            return registry;
+        }
+
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public static ICollectorRegistry UseProcessStats(this ICollectorRegistry registry, bool addLegacyMetrics)
+        {
+            return UseProcessStats(registry, string.Empty, addLegacyMetrics);
+        }
+
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public static ICollectorRegistry UseProcessStats(this ICollectorRegistry registry, string prefixName, bool addLegacyMetrics)
+        {
+            registry.Add(new ProcessCollector(Process.GetCurrentProcess(), prefixName, addLegacyMetrics));
 
             return registry;
         }

--- a/src/Prometheus.Client/Collectors/ProcessStats/CollectorRegistryExtensions.cs
+++ b/src/Prometheus.Client/Collectors/ProcessStats/CollectorRegistryExtensions.cs
@@ -6,7 +6,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
     {
         public static ICollectorRegistry UseProcessStats(this ICollectorRegistry registry)
         {
-            return UseProcessStats(registry, "");
+            return UseProcessStats(registry, string.Empty);
         }
 
         public static ICollectorRegistry UseProcessStats(this ICollectorRegistry registry, string prefixName)

--- a/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
+++ b/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
@@ -14,7 +14,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
         private readonly string _cpuSecondsTotalName;
         private readonly string _virtualMemoryBytesName;
         private readonly string _workingSetName;
-        private readonly string _privateBytesName;
+        private readonly string _privateMemoryBytesName;
         private readonly string _numThreadsName;
         private readonly string _processIdName;
         private readonly string _startTimeSecondsName;
@@ -32,7 +32,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             _cpuSecondsTotalName = prefixName + "process_cpu_seconds_total";
             _virtualMemoryBytesName = prefixName + "process_virtual_memory_bytes";
             _workingSetName = prefixName + "process_working_set";
-            _privateBytesName = prefixName + "process_private_bytes";
+            _privateMemoryBytesName = prefixName + "process_private_memory_bytes";
             _numThreadsName = prefixName + "process_num_threads";
             _processIdName = prefixName + "process_processid";
             _startTimeSecondsName = prefixName + "process_start_time_seconds";
@@ -41,7 +41,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             Configuration = new CollectorConfiguration(nameof(ProcessCollector));
 
             _processStartTime = ((DateTimeOffset)_process.StartTime.ToUniversalTime()).ToUnixTimeSeconds();
-            MetricNames = new[] { _cpuSecondsTotalName, _virtualMemoryBytesName, _workingSetName, _privateBytesName, _numThreadsName, _processIdName, _startTimeSecondsName };
+            MetricNames = new[] { _cpuSecondsTotalName, _virtualMemoryBytesName, _workingSetName, _privateMemoryBytesName, _numThreadsName, _processIdName, _startTimeSecondsName };
         }
 
         public CollectorConfiguration Configuration { get; }
@@ -64,7 +64,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             writer.WriteSample(_process.WorkingSet64);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_privateBytesName, MetricType.Gauge, "Process private memory size");
+            writer.WriteMetricHeader(_privateMemoryBytesName, MetricType.Gauge, "Process private memory size in bytes");
             writer.WriteSample(_process.PrivateMemorySize64);
             writer.EndMetric();
 

--- a/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
+++ b/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
@@ -13,7 +13,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
     {
         private readonly string _cpuSecondsTotalName;
         private readonly string _virtualMemoryBytesName;
-        private readonly string _workingSetName;
+        private readonly string _workingSetBytesName;
         private readonly string _privateMemoryBytesName;
         private readonly string _numThreadsName;
         private readonly string _processIdName;
@@ -31,7 +31,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
         {
             _cpuSecondsTotalName = prefixName + "process_cpu_seconds_total";
             _virtualMemoryBytesName = prefixName + "process_virtual_memory_bytes";
-            _workingSetName = prefixName + "process_working_set";
+            _workingSetBytesName = prefixName + "process_working_set_bytes";
             _privateMemoryBytesName = prefixName + "process_private_memory_bytes";
             _numThreadsName = prefixName + "process_num_threads";
             _processIdName = prefixName + "process_processid";
@@ -41,7 +41,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             Configuration = new CollectorConfiguration(nameof(ProcessCollector));
 
             _processStartTime = ((DateTimeOffset)_process.StartTime.ToUniversalTime()).ToUnixTimeSeconds();
-            MetricNames = new[] { _cpuSecondsTotalName, _virtualMemoryBytesName, _workingSetName, _privateMemoryBytesName, _numThreadsName, _processIdName, _startTimeSecondsName };
+            MetricNames = new[] { _cpuSecondsTotalName, _virtualMemoryBytesName, _workingSetBytesName, _privateMemoryBytesName, _numThreadsName, _processIdName, _startTimeSecondsName };
         }
 
         public CollectorConfiguration Configuration { get; }
@@ -60,7 +60,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             writer.WriteSample(_process.VirtualMemorySize64);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_workingSetName, MetricType.Gauge, "Process working set");
+            writer.WriteMetricHeader(_workingSetBytesName, MetricType.Gauge, "Process working set in bytes");
             writer.WriteSample(_process.WorkingSet64);
             writer.EndMetric();
 

--- a/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
+++ b/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Prometheus.Client.MetricsWriter;
 
+#pragma warning disable CS0618
+
 namespace Prometheus.Client.Collectors.ProcessStats
 {
     /// <inheritdoc />
@@ -11,14 +13,25 @@ namespace Prometheus.Client.Collectors.ProcessStats
     /// </summary>
     public class ProcessCollector : ICollector
     {
-        private readonly string _cpuSecondsTotalName;
-        private readonly string _virtualMemoryBytesName;
-        private readonly string _workingSetBytesName;
-        private readonly string _privateMemoryBytesName;
-        private readonly string _numThreadsName;
-        private readonly string _openHandlesName;
         private readonly string _processIdName;
+        private const string _processIdHelp = "Process ID";
+
+        private readonly string _cpuSecondsTotalName;
+        private const string _cpuSecondsTotalHelp = "Total user and system CPU time spent in seconds";
         private readonly string _startTimeSecondsName;
+        private const string _startTimeSecondsHelp = "Start time of the process since unix epoch in seconds";
+
+        private readonly string _virtualMemoryBytesName;
+        private const string _virtualMemoryBytesHelp = "Process virtual memory size in bytes";
+        private readonly string _workingSetBytesName;
+        private const string _workingSetBytesHelp = "Process working set in bytes";
+        private readonly string _privateMemoryBytesName;
+        private const string _privateMemoryBytesHelp = "Process private memory size in bytes";
+
+        private readonly string _numThreadsName;
+        private const string _numThreadsHelp = "Total number of threads";
+        private readonly string _openHandlesName;
+        private const string _openHandlesHelp = "Number of open handles";
 
         private readonly Process _process;
         private readonly double _processStartTime;
@@ -61,35 +74,35 @@ namespace Prometheus.Client.Collectors.ProcessStats
         {
             _process.Refresh();
 
-            writer.WriteMetricHeader(_processIdName, MetricType.Gauge, "Process ID");
+            writer.WriteMetricHeader(_processIdName, MetricType.Gauge, _processIdHelp);
             writer.WriteSample(_process.Id);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_cpuSecondsTotalName, MetricType.Counter, "Total user and system CPU time spent in seconds");
+            writer.WriteMetricHeader(_cpuSecondsTotalName, MetricType.Counter, _cpuSecondsTotalHelp);
             writer.WriteSample(_process.TotalProcessorTime.TotalSeconds);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_startTimeSecondsName, MetricType.Gauge, "Start time of the process since unix epoch in seconds");
+            writer.WriteMetricHeader(_startTimeSecondsName, MetricType.Gauge, _startTimeSecondsHelp);
             writer.WriteSample(_processStartTime);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_virtualMemoryBytesName, MetricType.Gauge, "Process virtual memory size in bytes");
+            writer.WriteMetricHeader(_virtualMemoryBytesName, MetricType.Gauge, _virtualMemoryBytesHelp);
             writer.WriteSample(_process.VirtualMemorySize64);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_workingSetBytesName, MetricType.Gauge, "Process working set in bytes");
+            writer.WriteMetricHeader(_workingSetBytesName, MetricType.Gauge, _workingSetBytesHelp);
             writer.WriteSample(_process.WorkingSet64);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_privateMemoryBytesName, MetricType.Gauge, "Process private memory size in bytes");
+            writer.WriteMetricHeader(_privateMemoryBytesName, MetricType.Gauge, _privateMemoryBytesHelp);
             writer.WriteSample(_process.PrivateMemorySize64);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_numThreadsName, MetricType.Gauge, "Total number of threads");
+            writer.WriteMetricHeader(_numThreadsName, MetricType.Gauge, _numThreadsHelp);
             writer.WriteSample(_process.Threads.Count);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_openHandlesName, MetricType.Gauge, "Number of open handles");
+            writer.WriteMetricHeader(_openHandlesName, MetricType.Gauge, _openHandlesHelp);
             writer.WriteSample(_process.HandleCount);
             writer.EndMetric();
         }

--- a/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
+++ b/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
@@ -16,6 +16,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
         private readonly string _workingSetBytesName;
         private readonly string _privateMemoryBytesName;
         private readonly string _numThreadsName;
+        private readonly string _openHandlesName;
         private readonly string _processIdName;
         private readonly string _startTimeSecondsName;
 
@@ -34,6 +35,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             _workingSetBytesName = prefixName + "process_working_set_bytes";
             _privateMemoryBytesName = prefixName + "process_private_memory_bytes";
             _numThreadsName = prefixName + "process_num_threads";
+            _openHandlesName = prefixName + "process_open_handles";
             _processIdName = prefixName + "process_processid";
             _startTimeSecondsName = prefixName + "process_start_time_seconds";
 
@@ -41,7 +43,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             Configuration = new CollectorConfiguration(nameof(ProcessCollector));
 
             _processStartTime = ((DateTimeOffset)_process.StartTime.ToUniversalTime()).ToUnixTimeSeconds();
-            MetricNames = new[] { _cpuSecondsTotalName, _virtualMemoryBytesName, _workingSetBytesName, _privateMemoryBytesName, _numThreadsName, _processIdName, _startTimeSecondsName };
+            MetricNames = new[] { _cpuSecondsTotalName, _virtualMemoryBytesName, _workingSetBytesName, _privateMemoryBytesName, _numThreadsName, _openHandlesName, _processIdName, _startTimeSecondsName };
         }
 
         public CollectorConfiguration Configuration { get; }
@@ -70,6 +72,10 @@ namespace Prometheus.Client.Collectors.ProcessStats
 
             writer.WriteMetricHeader(_numThreadsName, MetricType.Gauge, "Total number of threads");
             writer.WriteSample(_process.Threads.Count);
+            writer.EndMetric();
+
+            writer.WriteMetricHeader(_openHandlesName, MetricType.Gauge, "Number of open handles");
+            writer.WriteSample(_process.HandleCount);
             writer.EndMetric();
 
             writer.WriteMetricHeader(_processIdName, MetricType.Gauge, "Process ID");

--- a/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
+++ b/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
@@ -73,7 +73,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             _workingSetBytesName = prefixName + "process_working_set_bytes";
             _legacyWorkingSetBytesName = prefixName + "process_working_set";
             _privateMemoryBytesName = prefixName + "process_private_memory_bytes";
-            _legacyPrivateMemoryBytesName = prefixName + "process_working_set";
+            _legacyPrivateMemoryBytesName = prefixName + "process_private_bytes";
 
             _numThreadsName = prefixName + "process_num_threads";
             _openHandlesName = prefixName + "process_open_handles";
@@ -142,7 +142,6 @@ namespace Prometheus.Client.Collectors.ProcessStats
                 writer.WriteSample(_process.PrivateMemorySize64);
                 writer.EndMetric();
             }
-
 
             writer.WriteMetricHeader(_privateMemoryBytesName, MetricType.Gauge, _privateMemoryBytesHelp);
             writer.WriteSample(_process.PrivateMemorySize64);

--- a/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
+++ b/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
@@ -12,7 +12,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
     public class ProcessCollector : ICollector
     {
         private readonly string _cpuSecondsTotalName;
-        private readonly string _virtualBytesName;
+        private readonly string _virtualMemoryBytesName;
         private readonly string _workingSetName;
         private readonly string _privateBytesName;
         private readonly string _numThreadsName;
@@ -30,7 +30,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
         public ProcessCollector(Process process, string prefixName)
         {
             _cpuSecondsTotalName = prefixName + "process_cpu_seconds_total";
-            _virtualBytesName = prefixName + "process_virtual_bytes";
+            _virtualMemoryBytesName = prefixName + "process_virtual_memory_bytes";
             _workingSetName = prefixName + "process_working_set";
             _privateBytesName = prefixName + "process_private_bytes";
             _numThreadsName = prefixName + "process_num_threads";
@@ -41,7 +41,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             Configuration = new CollectorConfiguration(nameof(ProcessCollector));
 
             _processStartTime = ((DateTimeOffset)_process.StartTime.ToUniversalTime()).ToUnixTimeSeconds();
-            MetricNames = new[] { _cpuSecondsTotalName, _virtualBytesName, _workingSetName, _privateBytesName, _numThreadsName, _processIdName, _startTimeSecondsName };
+            MetricNames = new[] { _cpuSecondsTotalName, _virtualMemoryBytesName, _workingSetName, _privateBytesName, _numThreadsName, _processIdName, _startTimeSecondsName };
         }
 
         public CollectorConfiguration Configuration { get; }
@@ -56,7 +56,7 @@ namespace Prometheus.Client.Collectors.ProcessStats
             writer.WriteSample(_process.TotalProcessorTime.TotalSeconds);
             writer.EndMetric();
 
-            writer.WriteMetricHeader(_virtualBytesName, MetricType.Gauge, "Process virtual memory size");
+            writer.WriteMetricHeader(_virtualMemoryBytesName, MetricType.Gauge, "Process virtual memory size in bytes");
             writer.WriteSample(_process.VirtualMemorySize64);
             writer.EndMetric();
 

--- a/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
+++ b/src/Prometheus.Client/Collectors/ProcessStats/ProcessCollector.cs
@@ -22,10 +22,13 @@ namespace Prometheus.Client.Collectors.ProcessStats
         private const string _startTimeSecondsHelp = "Start time of the process since unix epoch in seconds";
 
         private readonly string _virtualMemoryBytesName;
+        private readonly string _legacyVirtualMemoryBytesName;
         private const string _virtualMemoryBytesHelp = "Process virtual memory size in bytes";
         private readonly string _workingSetBytesName;
+        private readonly string _legacyWorkingSetBytesName;
         private const string _workingSetBytesHelp = "Process working set in bytes";
         private readonly string _privateMemoryBytesName;
+        private readonly string _legacyPrivateMemoryBytesName;
         private const string _privateMemoryBytesHelp = "Process private memory size in bytes";
 
         private readonly string _numThreadsName;
@@ -35,6 +38,11 @@ namespace Prometheus.Client.Collectors.ProcessStats
 
         private readonly Process _process;
         private readonly double _processStartTime;
+        private readonly bool _addLegacyMetrics;
+
+        public CollectorConfiguration Configuration { get; }
+
+        public IReadOnlyList<string> MetricNames { get; }
 
         public ProcessCollector(Process process)
             : this(process, string.Empty)
@@ -42,6 +50,18 @@ namespace Prometheus.Client.Collectors.ProcessStats
         }
 
         public ProcessCollector(Process process, string prefixName)
+            : this(process, prefixName, false)
+        {
+        }
+
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public ProcessCollector(Process process, bool addLegacyMetricNames)
+            : this(process, string.Empty, addLegacyMetricNames)
+        {
+        }
+
+        [Obsolete("'addLegacyMetrics' will be removed in future versions")]
+        public ProcessCollector(Process process, string prefixName, bool addLegacyMetrics)
         {
             _processIdName = prefixName + "process_processid";
 
@@ -49,26 +69,34 @@ namespace Prometheus.Client.Collectors.ProcessStats
             _startTimeSecondsName = prefixName + "process_start_time_seconds";
 
             _virtualMemoryBytesName = prefixName + "process_virtual_memory_bytes";
+            _legacyVirtualMemoryBytesName = prefixName + "process_virtual_bytes";
             _workingSetBytesName = prefixName + "process_working_set_bytes";
+            _legacyWorkingSetBytesName = prefixName + "process_working_set";
             _privateMemoryBytesName = prefixName + "process_private_memory_bytes";
+            _legacyPrivateMemoryBytesName = prefixName + "process_working_set";
 
             _numThreadsName = prefixName + "process_num_threads";
             _openHandlesName = prefixName + "process_open_handles";
 
             _process = process;
+
+            _addLegacyMetrics = addLegacyMetrics;
+
             Configuration = new CollectorConfiguration(nameof(ProcessCollector));
 
             _processStartTime = ((DateTimeOffset)_process.StartTime.ToUniversalTime()).ToUnixTimeSeconds();
-            MetricNames = new[]
-            {
-                _processIdName, _cpuSecondsTotalName, _startTimeSecondsName, _virtualMemoryBytesName, _workingSetBytesName, _privateMemoryBytesName, _numThreadsName,
-                _openHandlesName
-            };
+            MetricNames = _addLegacyMetrics
+                ? new[]
+                {
+                    _processIdName, _cpuSecondsTotalName, _startTimeSecondsName, _legacyVirtualMemoryBytesName, _virtualMemoryBytesName, _legacyWorkingSetBytesName,
+                    _workingSetBytesName, _legacyPrivateMemoryBytesName, _privateMemoryBytesName, _numThreadsName, _openHandlesName
+                }
+                : new[]
+                {
+                    _processIdName, _cpuSecondsTotalName, _startTimeSecondsName, _virtualMemoryBytesName, _workingSetBytesName, _privateMemoryBytesName, _numThreadsName,
+                    _openHandlesName
+                };
         }
-
-        public CollectorConfiguration Configuration { get; }
-
-        public IReadOnlyList<string> MetricNames { get; }
 
         public void Collect(IMetricsWriter writer)
         {
@@ -86,13 +114,35 @@ namespace Prometheus.Client.Collectors.ProcessStats
             writer.WriteSample(_processStartTime);
             writer.EndMetric();
 
+            if (_addLegacyMetrics)
+            {
+                writer.WriteMetricHeader(_legacyVirtualMemoryBytesName, MetricType.Gauge, _virtualMemoryBytesHelp);
+                writer.WriteSample(_process.VirtualMemorySize64);
+                writer.EndMetric();
+            }
+
             writer.WriteMetricHeader(_virtualMemoryBytesName, MetricType.Gauge, _virtualMemoryBytesHelp);
             writer.WriteSample(_process.VirtualMemorySize64);
             writer.EndMetric();
 
+            if (_addLegacyMetrics)
+            {
+                writer.WriteMetricHeader(_legacyWorkingSetBytesName, MetricType.Gauge, _workingSetBytesHelp);
+                writer.WriteSample(_process.WorkingSet64);
+                writer.EndMetric();
+            }
+
             writer.WriteMetricHeader(_workingSetBytesName, MetricType.Gauge, _workingSetBytesHelp);
             writer.WriteSample(_process.WorkingSet64);
             writer.EndMetric();
+
+            if (_addLegacyMetrics)
+            {
+                writer.WriteMetricHeader(_legacyPrivateMemoryBytesName, MetricType.Gauge, _privateMemoryBytesHelp);
+                writer.WriteSample(_process.PrivateMemorySize64);
+                writer.EndMetric();
+            }
+
 
             writer.WriteMetricHeader(_privateMemoryBytesName, MetricType.Gauge, _privateMemoryBytesHelp);
             writer.WriteSample(_process.PrivateMemorySize64);

--- a/tests/Prometheus.Client.Benchmarks.Comparison/Prometheus.Client.Benchmarks.Comparison.csproj
+++ b/tests/Prometheus.Client.Benchmarks.Comparison/Prometheus.Client.Benchmarks.Comparison.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <NoWarn>SA1133;CS1591</NoWarn>

--- a/tests/Prometheus.Client.Benchmarks/Prometheus.Client.Benchmarks.csproj
+++ b/tests/Prometheus.Client.Benchmarks/Prometheus.Client.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>SA1133;CS1591</NoWarn>
     <OutputType>Exe</OutputType>

--- a/tests/Prometheus.Client.Tests/CollectorTests/CollectorRegistryExtensionsTests.cs
+++ b/tests/Prometheus.Client.Tests/CollectorTests/CollectorRegistryExtensionsTests.cs
@@ -1,0 +1,42 @@
+using Prometheus.Client.Collectors;
+using Prometheus.Client.Collectors.DotNetStats;
+using Prometheus.Client.Collectors.ProcessStats;
+using Xunit;
+
+namespace Prometheus.Client.Tests.CollectorTests
+{
+    public class CollectorRegistryExtensionsTests
+    {
+        [Fact]
+        public void UseDotNetStats_TryGet()
+        {
+            var collectorRegistry = new CollectorRegistry();
+            collectorRegistry.UseDotNetStats();
+
+            Assert.True(collectorRegistry.TryGet(nameof(GCCollectionCountCollector), out _));
+            Assert.True(collectorRegistry.TryGet(nameof(GCTotalMemoryCollector), out _));
+        }
+        
+        [Fact]
+        public void UseProcessStats_TryGet()
+        {
+            var collectorRegistry = new CollectorRegistry();
+            collectorRegistry.UseProcessStats();
+
+            Assert.True(collectorRegistry.TryGet(nameof(ProcessCollector), out _));
+        }
+        
+        [Fact]
+        public void UseDefaultCollectors_TryGet()
+        {
+            var collectorRegistry = new CollectorRegistry();
+            collectorRegistry.UseDefaultCollectors();
+
+            Assert.True(collectorRegistry.TryGet(nameof(GCCollectionCountCollector), out _));
+            Assert.True(collectorRegistry.TryGet(nameof(GCTotalMemoryCollector), out _));
+            Assert.True(collectorRegistry.TryGet(nameof(ProcessCollector), out _));
+        }
+        
+        //TODO: add more checks
+    }
+}

--- a/tests/Prometheus.Client.Tests/CollectorTests/CollectorRegistryExtensionsTests.cs
+++ b/tests/Prometheus.Client.Tests/CollectorTests/CollectorRegistryExtensionsTests.cs
@@ -16,7 +16,17 @@ namespace Prometheus.Client.Tests.CollectorTests
             Assert.True(collectorRegistry.TryGet(nameof(GCCollectionCountCollector), out _));
             Assert.True(collectorRegistry.TryGet(nameof(GCTotalMemoryCollector), out _));
         }
-        
+
+        [Fact]
+        public void UseDotNetStatsWithPrefix_TryGet()
+        {
+            var collectorRegistry = new CollectorRegistry();
+            collectorRegistry.UseDotNetStats("prefix");
+
+            Assert.True(collectorRegistry.TryGet(nameof(GCCollectionCountCollector), out _));
+            Assert.True(collectorRegistry.TryGet(nameof(GCTotalMemoryCollector), out _));
+        }
+
         [Fact]
         public void UseProcessStats_TryGet()
         {
@@ -25,7 +35,16 @@ namespace Prometheus.Client.Tests.CollectorTests
 
             Assert.True(collectorRegistry.TryGet(nameof(ProcessCollector), out _));
         }
-        
+
+        [Fact]
+        public void UseProcessStatsWithPrefix_TryGet()
+        {
+            var collectorRegistry = new CollectorRegistry();
+            collectorRegistry.UseProcessStats("prefix");
+
+            Assert.True(collectorRegistry.TryGet(nameof(ProcessCollector), out _));
+        }
+
         [Fact]
         public void UseDefaultCollectors_TryGet()
         {
@@ -36,7 +55,16 @@ namespace Prometheus.Client.Tests.CollectorTests
             Assert.True(collectorRegistry.TryGet(nameof(GCTotalMemoryCollector), out _));
             Assert.True(collectorRegistry.TryGet(nameof(ProcessCollector), out _));
         }
-        
-        //TODO: add more checks
+
+        [Fact]
+        public void UseDefaultCollectorsWithPrefix_TryGet()
+        {
+            var collectorRegistry = new CollectorRegistry();
+            collectorRegistry.UseDefaultCollectors("prefix");
+
+            Assert.True(collectorRegistry.TryGet(nameof(GCCollectionCountCollector), out _));
+            Assert.True(collectorRegistry.TryGet(nameof(GCTotalMemoryCollector), out _));
+            Assert.True(collectorRegistry.TryGet(nameof(ProcessCollector), out _));
+        }
     }
 }

--- a/tests/Prometheus.Client.Tests/CollectorTests/GCTotalMemoryCollectorTests.cs
+++ b/tests/Prometheus.Client.Tests/CollectorTests/GCTotalMemoryCollectorTests.cs
@@ -21,6 +21,22 @@ namespace Prometheus.Client.Tests.CollectorTests
             Assert.Equal(prefixName + "dotnet_total_memory_bytes", collector.MetricNames.First());
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData("123")]
+        [InlineData("promitor_")]
+        [InlineData("myprefix_")]
+        public void Check_MetricNames_WithAddLegacy(string prefixName)
+        {
+            var collector = new GCTotalMemoryCollector(prefixName, true);
+
+            var legacyMetric = collector.MetricNames[0];
+            var metric = collector.MetricNames[1];
+
+            Assert.Equal(prefixName + "dotnet_totalmemory", legacyMetric);
+            Assert.Equal(prefixName + "dotnet_total_memory_bytes", metric);
+        }
+
         [Fact]
         public void Check_Collect_NoPrefix()
         {

--- a/tests/Prometheus.Client.Tests/CollectorTests/GCTotalMemoryCollectorTests.cs
+++ b/tests/Prometheus.Client.Tests/CollectorTests/GCTotalMemoryCollectorTests.cs
@@ -51,6 +51,20 @@ namespace Prometheus.Client.Tests.CollectorTests
             Assert.Contains("# TYPE dotnet_total_memory_bytes gauge", response);
         }
 
+        [Fact]
+        public void Check_Collect_NoPrefix_WithAddLegacy()
+        {
+            using var stream = new MemoryStream();
+            var metricWriter = new MetricsTextWriter(stream);
+            var collector = new GCTotalMemoryCollector(true);
+            collector.Collect(metricWriter);
+            metricWriter.FlushAsync();
+
+            var response = Encoding.UTF8.GetString(stream.ToArray());
+
+            Assert.Contains("# TYPE dotnet_totalmemory gauge", response);
+        }
+
         [Theory]
         [InlineData("")]
         [InlineData("123")]

--- a/tests/Prometheus.Client.Tests/CollectorTests/GCTotalMemoryCollectorTests.cs
+++ b/tests/Prometheus.Client.Tests/CollectorTests/GCTotalMemoryCollectorTests.cs
@@ -18,7 +18,7 @@ namespace Prometheus.Client.Tests.CollectorTests
         {
             var collector = new GCTotalMemoryCollector(prefixName);
 
-            Assert.Equal(prefixName + "dotnet_totalmemory", collector.MetricNames.First());
+            Assert.Equal(prefixName + "dotnet_total_memory_bytes", collector.MetricNames.First());
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace Prometheus.Client.Tests.CollectorTests
 
             var response = Encoding.UTF8.GetString(stream.ToArray());
 
-            Assert.Contains("# TYPE dotnet_totalmemory gauge", response);
+            Assert.Contains("# TYPE dotnet_total_memory_bytes gauge", response);
         }
 
         [Theory]
@@ -50,7 +50,7 @@ namespace Prometheus.Client.Tests.CollectorTests
 
             var response = Encoding.UTF8.GetString(stream.ToArray());
 
-            Assert.Contains($"# TYPE {prefixName}dotnet_totalmemory gauge", response);
+            Assert.Contains($"# TYPE {prefixName}dotnet_total_memory_bytes gauge", response);
         }
     }
 }

--- a/tests/Prometheus.Client.Tests/CollectorTests/ProcessCollectorTests.cs
+++ b/tests/Prometheus.Client.Tests/CollectorTests/ProcessCollectorTests.cs
@@ -19,9 +19,9 @@ namespace Prometheus.Client.Tests.CollectorTests
             var collector = new ProcessCollector(Process.GetCurrentProcess(), prefixName);
 
             Assert.Contains(prefixName + "process_cpu_seconds_total", collector.MetricNames);
-            Assert.Contains(prefixName + "process_virtual_bytes", collector.MetricNames);
-            Assert.Contains(prefixName + "process_working_set", collector.MetricNames);
-            Assert.Contains(prefixName + "process_private_bytes", collector.MetricNames);
+            Assert.Contains(prefixName + "process_virtual_memory_bytes", collector.MetricNames);
+            Assert.Contains(prefixName + "process_working_set_bytes", collector.MetricNames);
+            Assert.Contains(prefixName + "process_private_memory_bytes", collector.MetricNames);
             Assert.Contains(prefixName + "process_num_threads", collector.MetricNames);
             Assert.Contains(prefixName + "process_processid", collector.MetricNames);
             Assert.Contains(prefixName + "process_start_time_seconds", collector.MetricNames);
@@ -39,9 +39,9 @@ namespace Prometheus.Client.Tests.CollectorTests
             var response = Encoding.UTF8.GetString(stream.ToArray());
 
             Assert.Contains("# TYPE process_cpu_seconds_total counter", response);
-            Assert.Contains("# TYPE process_virtual_bytes gauge", response);
-            Assert.Contains("# TYPE process_working_set gauge", response);
-            Assert.Contains("# TYPE process_private_bytes gauge", response);
+            Assert.Contains("# TYPE process_virtual_memory_bytes gauge", response);
+            Assert.Contains("# TYPE process_working_set_bytes gauge", response);
+            Assert.Contains("# TYPE process_private_memory_bytes gauge", response);
             Assert.Contains("# TYPE process_num_threads gauge", response);
             Assert.Contains("# TYPE process_processid gauge", response);
             Assert.Contains("# TYPE process_start_time_seconds gauge", response);
@@ -64,9 +64,9 @@ namespace Prometheus.Client.Tests.CollectorTests
             var response = Encoding.UTF8.GetString(stream.ToArray());
 
             Assert.Contains($"# TYPE {prefixName}process_cpu_seconds_total counter", response);
-            Assert.Contains($"# TYPE {prefixName}process_virtual_bytes gauge", response);
-            Assert.Contains($"# TYPE {prefixName}process_working_set gauge", response);
-            Assert.Contains($"# TYPE {prefixName}process_private_bytes gauge", response);
+            Assert.Contains($"# TYPE {prefixName}process_virtual_memory_bytes gauge", response);
+            Assert.Contains($"# TYPE {prefixName}process_working_set_bytes gauge", response);
+            Assert.Contains($"# TYPE {prefixName}process_private_memory_bytes gauge", response);
             Assert.Contains($"# TYPE {prefixName}process_num_threads gauge", response);
             Assert.Contains($"# TYPE {prefixName}process_processid gauge", response);
             Assert.Contains($"# TYPE {prefixName}process_start_time_seconds gauge", response);

--- a/tests/Prometheus.Client.Tests/CollectorTests/ProcessCollectorTests.cs
+++ b/tests/Prometheus.Client.Tests/CollectorTests/ProcessCollectorTests.cs
@@ -26,6 +26,27 @@ namespace Prometheus.Client.Tests.CollectorTests
             Assert.Contains(prefixName + "process_processid", collector.MetricNames);
             Assert.Contains(prefixName + "process_start_time_seconds", collector.MetricNames);
         }
+        
+        [Theory]
+        [InlineData("")]
+        [InlineData("123")]
+        [InlineData("promitor_")]
+        [InlineData("myprefix_")]
+        public void Check_MetricNames_WithAddLegacy(string prefixName)
+        {
+            var collector = new ProcessCollector(Process.GetCurrentProcess(), prefixName, true);
+
+            Assert.Contains(prefixName + "process_cpu_seconds_total", collector.MetricNames);
+            Assert.Contains(prefixName + "process_virtual_bytes", collector.MetricNames);
+            Assert.Contains(prefixName + "process_virtual_memory_bytes", collector.MetricNames);
+            Assert.Contains(prefixName + "process_working_set", collector.MetricNames);
+            Assert.Contains(prefixName + "process_working_set_bytes", collector.MetricNames);
+            Assert.Contains(prefixName + "process_private_bytes", collector.MetricNames);
+            Assert.Contains(prefixName + "process_private_memory_bytes", collector.MetricNames);
+            Assert.Contains(prefixName + "process_num_threads", collector.MetricNames);
+            Assert.Contains(prefixName + "process_processid", collector.MetricNames);
+            Assert.Contains(prefixName + "process_start_time_seconds", collector.MetricNames);
+        }
 
         [Fact]
         public void Check_Collect_NoPrefix()
@@ -41,6 +62,29 @@ namespace Prometheus.Client.Tests.CollectorTests
             Assert.Contains("# TYPE process_cpu_seconds_total counter", response);
             Assert.Contains("# TYPE process_virtual_memory_bytes gauge", response);
             Assert.Contains("# TYPE process_working_set_bytes gauge", response);
+            Assert.Contains("# TYPE process_private_memory_bytes gauge", response);
+            Assert.Contains("# TYPE process_num_threads gauge", response);
+            Assert.Contains("# TYPE process_processid gauge", response);
+            Assert.Contains("# TYPE process_start_time_seconds gauge", response);
+        }
+        
+        [Fact]
+        public void Check_Collect_NoPrefix_WithAddLegacy()
+        {
+            using var stream = new MemoryStream();
+            var metricWriter = new MetricsTextWriter(stream);
+            var collector = new ProcessCollector(Process.GetCurrentProcess(), true);
+            collector.Collect(metricWriter);
+            metricWriter.FlushAsync();
+
+            var response = Encoding.UTF8.GetString(stream.ToArray());
+
+            Assert.Contains("# TYPE process_cpu_seconds_total counter", response);
+            Assert.Contains("# TYPE process_virtual_bytes gauge", response);
+            Assert.Contains("# TYPE process_virtual_memory_bytes gauge", response);
+            Assert.Contains("# TYPE process_working_set gauge", response);
+            Assert.Contains("# TYPE process_working_set_bytes gauge", response);
+            Assert.Contains("# TYPE process_private_bytes gauge", response);
             Assert.Contains("# TYPE process_private_memory_bytes gauge", response);
             Assert.Contains("# TYPE process_num_threads gauge", response);
             Assert.Contains("# TYPE process_processid gauge", response);

--- a/tests/Prometheus.Client.Tests/Prometheus.Client.Tests.csproj
+++ b/tests/Prometheus.Client.Tests/Prometheus.Client.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../Prometheus.Client.snk</AssemblyOriginatorKeyFile>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="UntypedTests\Resources\CounterTests_SuppressEmpty.txt" />


### PR DESCRIPTION
Rename metrics:

```sh
process_virtual_bytes -> process_virtual_memory_bytes
process_private_bytes -> process_private_memory_bytes
process_working_set -> process_working_set_bytes
dotnet_totalmemory -> dotnet_total_memory_bytes
```
Add metrics:

```sh
process_open_handles
```


Should be compatible with https://grafana.com/grafana/dashboards/10427