### PR TITLE
Change MetricFamily dictionary key from 32 to 64 bits hash to reduce collisions

### DIFF
--- a/src/Prometheus.Client/LabelsHelper.cs
+++ b/src/Prometheus.Client/LabelsHelper.cs
@@ -61,19 +61,19 @@ internal static class LabelsHelper
 #endif
     }
 
-    public static int GetHashCode<TTuple>(TTuple values)
+    public static int GetHashCode<TTuple>(TTuple values, int seed = 0)
 #if NET6_0_OR_GREATER
         where TTuple : struct, ITuple, IEquatable<TTuple>
 #else
         where TTuple : struct, IEquatable<TTuple>
 #endif
     {
-        return TupleHelper<TTuple>.GetTupleHashCode(values);
+        return TupleHelper<TTuple>.GetTupleHashCode(values, seed);
     }
 
-    public static int GetHashCode(IReadOnlyList<string> values)
+    public static int GetHashCode(IReadOnlyList<string> values, int seed = 0)
     {
-        var result = 0;
+        var result = seed;
 
         // ReSharper disable once ForCanBeConvertedToForeach
         // do not use for-each here, it allocates which is easy to avoid by for loop
@@ -260,9 +260,9 @@ internal static class LabelsHelper
             });
         }
 
-        public static int GetTupleHashCode(TTuple values)
+        public static int GetTupleHashCode(TTuple values, int seed)
         {
-            return _hashCodeReducer(values, 0, (item, _, aggregated) =>
+            return _hashCodeReducer(values, seed, (item, _, aggregated) =>
             {
                 if (item == null)
                     throw new ArgumentException("Label value cannot be empty");


### PR DESCRIPTION
# Context

The `MetricFamily` uses a 32-bit hashes of the labels as keys to disambiguate series. This can be an issue as collisions are very common on such a narrow space.

According to [the birthday paradox](https://lemire.me/blog/2013/06/17/hashing-and-the-birthday-paradox-cautionary-tale/), and considering a good hash function (which `HashCode.Combine` is), there is a 50% chance of collisions for 77163 32-bit hashes. In our case, that translate to as many chances to have two series colliding, resulting in metrics data to be mixed up, which can be very nasty to debug.

To prove this point, here is a test that shows that collisions do happen:
```csharp
[Fact]
public async Task TestCollisions()
{
    const int seriesCount = 77163;
    string output = await CollectionTestHelper.CollectAsync(factory => {
        var counter = factory.CreateCounter("test", "with help text", ("label1", "label2"));

        ulong c = 0;
        string GetNextUniqueString()
        {
            return c++.ToString();
        }

        for (int i = 0; i < seriesCount; i++)
        {
            counter.WithLabels((GetNextUniqueString(), GetNextUniqueString())).Inc(5.5);
        }
    });

    // Name + description + 1_000_000 samples + 1 empty line
    Assert.Equal(seriesCount + 3, output.Split('\n').Length);
}
```
This test does fail about 50% of the time.

# Solution

A solution would be to compare labels when checking for equality. This however would require some changes due to the support of pre-.NET6 because of the missing `ITuple` interface, requiring more usage of compiled expression, which would complexify the code.

Instead, I propose to increase the hash width to 64-bit. This can be easily done by replacing the Int32 by a struct containing two Int32: one that remains used as a key, as we do today, but a second one to then check the equality, effectively reducing the odds of collision by a factor 77163, if I'm correct. That brings us to having to generate 5954128569 series to have a 50% chance of collisions, which to be goes from "quite likely to have collisions" to "very unlikely".

Of course, the two generated hashes need to be different, that's why I introduced a seed, which was quite an easy addition given the current code.

This PR presents this solution.

## Performance

I ran the `CounterUsage` benchmark on my Macbook pro M1:

| Method           | Mean     | Error    | StdDev   | Median   | Min      | Max      | Gen0   | Allocated |
|----------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| LabelledCreation Before | 32.58 ns | 0.180 ns | 0.150 ns | 32.30 ns | 32.81 ns | 32.56 ns | 0.0063 |      40 B |
| LabelledCreation After | 54.77 ns | 0.210 ns | 0.175 ns | 54.70 ns | 54.55 ns | 55.22 ns | 0.0063 |      40 B |

It seems this changes does have a small performance cost, which I think is acceptable considering the issue this addresses. If this is a concern, an improvement could be to generate a single 64-bit hash instead, but that would be require access to such function, which I don't think we have pre .NET 6 without a third party library.