### PR TITLE
Add time-to-live feature

### DIFF
--- a/src/Prometheus.Client.Abstractions/IMetricFactory.cs
+++ b/src/Prometheus.Client.Abstractions/IMetricFactory.cs
@@ -15,7 +15,8 @@ namespace Prometheus.Client
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        ICounter CreateCounter(string name, string help, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        ICounter CreateCounter(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create  Counter.
@@ -24,16 +25,18 @@ namespace Prometheus.Client
         /// <param name="help">Help text.</param>
         /// <param name="labelName">Label name</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IMetricFamily<ICounter, ValueTuple<string>> CreateCounter(string name, string help, string labelName, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        IMetricFamily<ICounter, ValueTuple<string>> CreateCounter(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create  Counter.
         /// </summary>
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
-        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
         /// <param name="labelNames">Label names</param>
-        IMetricFamily<ICounter, TLabels> CreateCounter<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        IMetricFamily<ICounter, TLabels> CreateCounter<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
             where TLabels : struct, ITuple, IEquatable<TLabels>;
 #else
@@ -58,12 +61,23 @@ namespace Prometheus.Client
         IMetricFamily<ICounter> CreateCounter(string name, string help, bool includeTimestamp = false, params string[] labelNames);
 
         /// <summary>
+        ///     Create  Counter.
+        /// </summary>
+        /// <param name="name">Metric name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        /// <param name="labelNames">Label names</param>
+        IMetricFamily<ICounter> CreateCounter(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames);
+
+        /// <summary>
         ///     Create int-based Counter.
         /// </summary>
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        ICounter<long> CreateCounterInt64(string name, string help, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        ICounter<long> CreateCounterInt64(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create int-based Counter.
@@ -72,16 +86,18 @@ namespace Prometheus.Client
         /// <param name="help">Help text.</param>
         /// <param name="labelName">Label name</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IMetricFamily<ICounter<long>, ValueTuple<string>> CreateCounterInt64(string name, string help, string labelName, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        IMetricFamily<ICounter<long>, ValueTuple<string>> CreateCounterInt64(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create int-based Counter.
         /// </summary>
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
-        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
         /// <param name="labelNames">Label names</param>
-        IMetricFamily<ICounter<long>, TLabels> CreateCounterInt64<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        IMetricFamily<ICounter<long>, TLabels> CreateCounterInt64<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
             where TLabels : struct, ITuple, IEquatable<TLabels>;
 #else
@@ -106,21 +122,33 @@ namespace Prometheus.Client
         IMetricFamily<ICounter<long>> CreateCounterInt64(string name, string help, bool includeTimestamp = false, params string[] labelNames);
 
         /// <summary>
+        ///     Create int-based Counter.
+        /// </summary>
+        /// <param name="name">Metric name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not set for the given duration</param>
+        /// <param name="labelNames">Label names</param>
+        IMetricFamily<ICounter<long>> CreateCounterInt64(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames);
+
+        /// <summary>
         ///     Create Gauge.
         /// </summary>
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IGauge CreateGauge(string name, string help, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not set for the given duration</param>
+        IGauge CreateGauge(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create Gauge.
         /// </summary>
         /// <param name="name">Name.</param>
         /// <param name="help">Help text.</param>
-        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
         /// <param name="labelNames">Label names</param>
-        IMetricFamily<IGauge, TLabels> CreateGauge<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not set for the given duration</param>
+        IMetricFamily<IGauge, TLabels> CreateGauge<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
             where TLabels : struct, ITuple, IEquatable<TLabels>;
 #else
@@ -142,7 +170,8 @@ namespace Prometheus.Client
         /// <param name="help">Help text.</param>
         /// <param name="labelName">Label name</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IMetricFamily<IGauge, ValueTuple<string>> CreateGauge(string name, string help, string labelName, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not set for the given duration</param>
+        IMetricFamily<IGauge, ValueTuple<string>> CreateGauge(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create Gauge.
@@ -154,12 +183,23 @@ namespace Prometheus.Client
         IMetricFamily<IGauge> CreateGauge(string name, string help, bool includeTimestamp = false, params string[] labelNames);
 
         /// <summary>
+        ///     Create Gauge.
+        /// </summary>
+        /// <param name="name">Metric name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not set for the given duration</param>
+        /// <param name="labelNames">Label names</param>
+        IMetricFamily<IGauge> CreateGauge(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames);
+
+        /// <summary>
         ///     Create int-based Gauge.
         /// </summary>
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IGauge<long> CreateGaugeInt64(string name, string help, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not set for the given duration</param>
+        IGauge<long> CreateGaugeInt64(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create int-based Gauge.
@@ -168,16 +208,18 @@ namespace Prometheus.Client
         /// <param name="help">Help text.</param>
         /// <param name="labelName">Label name</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IMetricFamily<IGauge<long>, ValueTuple<string>> CreateGaugeInt64(string name, string help, string labelName, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not set for the given duration</param>
+        IMetricFamily<IGauge<long>, ValueTuple<string>> CreateGaugeInt64(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create int-based Gauge.
         /// </summary>
         /// <param name="name">Name.</param>
         /// <param name="help">Help text.</param>
-        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
         /// <param name="labelNames">Label names</param>
-        IMetricFamily<IGauge<long>, TLabels> CreateGaugeInt64<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not set for the given duration</param>
+        IMetricFamily<IGauge<long>, TLabels> CreateGaugeInt64<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
             where TLabels : struct, ITuple, IEquatable<TLabels>;
 #else
@@ -202,33 +244,46 @@ namespace Prometheus.Client
         IMetricFamily<IGauge<long>> CreateGaugeInt64(string name, string help, bool includeTimestamp = false, params string[] labelNames);
 
         /// <summary>
-        ///     Create Histogram.
+        ///     Create int-based Gauge.
         /// </summary>
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
-        /// <param name="buckets">Buckets.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IHistogram CreateHistogram(string name, string help, bool includeTimestamp = false, double[] buckets = null);
+        /// <param name="timeToLive">Remove metric if not set for the given duration</param>
+        /// <param name="labelNames">Label names</param>
+        IMetricFamily<IGauge<long>> CreateGaugeInt64(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames);
 
         /// <summary>
         ///     Create Histogram.
         /// </summary>
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
         /// <param name="buckets">Buckets.</param>
+        IHistogram CreateHistogram(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, double[] buckets = null);
+
+        /// <summary>
+        ///     Create Histogram.
+        /// </summary>
+        /// <param name="name">Metric name.</param>
+        /// <param name="help">Help text.</param>
         /// <param name="labelName">Label name</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IMetricFamily<IHistogram, ValueTuple<string>> CreateHistogram(string name, string help, string labelName, bool includeTimestamp = false, double[] buckets = null);
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        /// <param name="buckets">Buckets.</param>
+        IMetricFamily<IHistogram, ValueTuple<string>> CreateHistogram(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default, double[] buckets = null);
 
         /// <summary>
         ///     Create Histogram.
         /// </summary>
         /// <param name="name">Name.</param>
         /// <param name="help">Help text.</param>
-        /// <param name="buckets">Buckets.</param>
-        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
         /// <param name="labelNames">Label names</param>
-        IMetricFamily<IHistogram, TLabels> CreateHistogram<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, double[] buckets = null)
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        /// <param name="buckets">Buckets.</param>
+        IMetricFamily<IHistogram, TLabels> CreateHistogram<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default, double[] buckets = null)
 #if NET6_0_OR_GREATER
             where TLabels : struct, ITuple, IEquatable<TLabels>;
 #else
@@ -266,10 +321,31 @@ namespace Prometheus.Client
         /// </summary>
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        /// <param name="labelNames">Label names</param>
+        IMetricFamily<IHistogram> CreateHistogram(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames);
+
+        /// <summary>
+        ///     Create Histogram.
+        /// </summary>
+        /// <param name="name">Metric name.</param>
+        /// <param name="help">Help text.</param>
         /// <param name="buckets">Buckets.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
         /// <param name="labelNames">Label names</param>
         IMetricFamily<IHistogram> CreateHistogram(string name, string help, bool includeTimestamp = false, double[] buckets = null, params string[] labelNames);
+
+        /// <summary>
+        ///     Create Histogram.
+        /// </summary>
+        /// <param name="name">Metric name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="buckets">Buckets.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        /// <param name="labelNames">Label names</param>
+        IMetricFamily<IHistogram> CreateHistogram(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, double[] buckets = null, params string[] labelNames);
 
         /// <summary>
         ///     Create Untyped.
@@ -277,7 +353,8 @@ namespace Prometheus.Client
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IUntyped CreateUntyped(string name, string help, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        IUntyped CreateUntyped(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create Untyped.
@@ -286,16 +363,18 @@ namespace Prometheus.Client
         /// <param name="help">Help text.</param>
         /// <param name="labelName">Label name</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
-        IMetricFamily<IUntyped, ValueTuple<string>> CreateUntyped(string name, string help, string labelName, bool includeTimestamp = false);
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        IMetricFamily<IUntyped, ValueTuple<string>> CreateUntyped(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default);
 
         /// <summary>
         ///     Create Untyped.
         /// </summary>
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
-        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
         /// <param name="labelNames">Label names</param>
-        IMetricFamily<IUntyped, TLabels> CreateUntyped<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
+        IMetricFamily<IUntyped, TLabels> CreateUntyped<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
             where TLabels : struct, ITuple, IEquatable<TLabels>;
 #else
@@ -316,8 +395,9 @@ namespace Prometheus.Client
         /// <param name="name">Metric name.</param>
         /// <param name="help">Help text.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
         /// <param name="labelNames">Label names</param>
-        IMetricFamily<IUntyped> CreateUntyped(string name, string help, bool includeTimestamp = false, params string[] labelNames);
+        IMetricFamily<IUntyped> CreateUntyped(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames);
 
         /// <summary>
         ///     Create Summary.
@@ -333,8 +413,9 @@ namespace Prometheus.Client
         /// <param name="name">Name.</param>
         /// <param name="help">Help text.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
         /// <param name="labelNames">Array of label names.</param>
-        IMetricFamily<ISummary> CreateSummary(string name, string help, bool includeTimestamp = false, params string[] labelNames);
+        IMetricFamily<ISummary> CreateSummary(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames);
 
         /// <summary>
         ///     Create Summary.
@@ -361,6 +442,7 @@ namespace Prometheus.Client
         /// <param name="name">Name.</param>
         /// <param name="help">Help text.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
         /// <param name="objectives">.</param>
         /// <param name="maxAge"></param>
         /// <param name="ageBuckets"></param>
@@ -369,6 +451,7 @@ namespace Prometheus.Client
             string name,
             string help,
             bool includeTimestamp = false,
+            TimeSpan timeToLive = default,
             IReadOnlyList<QuantileEpsilonPair> objectives = null,
             TimeSpan? maxAge = null,
             int? ageBuckets = null,
@@ -381,6 +464,7 @@ namespace Prometheus.Client
         /// <param name="help">Help text.</param>
         /// <param name="labelName">Label name.</param>
         /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
         /// <param name="objectives">.</param>
         /// <param name="maxAge"></param>
         /// <param name="ageBuckets"></param>
@@ -390,6 +474,7 @@ namespace Prometheus.Client
             string help,
             string labelName,
             bool includeTimestamp = false,
+            TimeSpan timeToLive = default,
             IReadOnlyList<QuantileEpsilonPair> objectives = null,
             TimeSpan? maxAge = null,
             int? ageBuckets = null,
@@ -400,8 +485,9 @@ namespace Prometheus.Client
         /// </summary>
         /// <param name="name">Name.</param>
         /// <param name="help">Help text.</param>
-        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
         /// <param name="labelNames">Array of label names.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
         /// <param name="objectives">.</param>
         /// <param name="maxAge"></param>
         /// <param name="ageBuckets"></param>
@@ -411,6 +497,7 @@ namespace Prometheus.Client
             string help,
             TLabels labelNames,
             bool includeTimestamp = false,
+            TimeSpan timeToLive = default,
             IReadOnlyList<QuantileEpsilonPair> objectives = null,
             TimeSpan? maxAge = null,
             int? ageBuckets = null,
@@ -426,8 +513,9 @@ namespace Prometheus.Client
         /// </summary>
         /// <param name="name">Name.</param>
         /// <param name="help">Help text.</param>
-        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
         /// <param name="labelNames">Array of label names.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="timeToLive">Remove metric if not incremented for the given duration</param>
         /// <param name="objectives">.</param>
         /// <param name="maxAge"></param>
         /// <param name="ageBuckets"></param>
@@ -437,6 +525,7 @@ namespace Prometheus.Client
             string help,
             string[] labelNames,
             bool includeTimestamp,
+            TimeSpan timeToLive = default,
             IReadOnlyList<QuantileEpsilonPair> objectives = null,
             TimeSpan? maxAge = null,
             int? ageBuckets = null,

--- a/src/Prometheus.Client/HistogramConfiguration.cs
+++ b/src/Prometheus.Client/HistogramConfiguration.cs
@@ -16,8 +16,8 @@ public class HistogramConfiguration : MetricConfiguration
         _defaultFormattedBuckets = GetFormattedBuckets(_defaultBuckets);
     }
 
-    public HistogramConfiguration(string name, string help, string[] labels, double[] buckets, bool includeTimestamp)
-        : base(name, help, labels, includeTimestamp)
+    public HistogramConfiguration(string name, string help, string[] labels, double[] buckets, bool includeTimestamp, TimeSpan timeToLive)
+        : base(name, help, labels, includeTimestamp, timeToLive)
     {
         if (LabelNames.Any(l => l == "le"))
             throw new ArgumentException("'le' is a reserved label name");

--- a/src/Prometheus.Client/MetricBase.cs
+++ b/src/Prometheus.Client/MetricBase.cs
@@ -12,7 +12,7 @@ public abstract class MetricBase<TConfig>
     protected readonly TConfig Configuration;
     private readonly bool _includeTimestamp;
     private readonly bool _computeTimestamp;
-    private TimeSpan _timeToLive;
+    private readonly TimeSpan _timeToLive;
     private readonly Func<DateTimeOffset> _currentTimeProvider;
     private long _timestamp;
 

--- a/src/Prometheus.Client/MetricConfiguration.cs
+++ b/src/Prometheus.Client/MetricConfiguration.cs
@@ -7,11 +7,12 @@ namespace Prometheus.Client;
 
 public class MetricConfiguration : CollectorConfiguration
 {
-    public MetricConfiguration(string name, string help, string[] labels, bool includeTimestamp)
+    public MetricConfiguration(string name, string help, string[] labels, bool includeTimestamp, TimeSpan timeToLive)
         : base(name)
     {
         Help = help;
         IncludeTimestamp = includeTimestamp;
+        TimeToLive = timeToLive == TimeSpan.MaxValue ? TimeSpan.Zero : timeToLive;
         LabelNames = labels ?? Array.Empty<string>();
 
         if (labels != null)
@@ -30,6 +31,8 @@ public class MetricConfiguration : CollectorConfiguration
     public string Help { get; }
 
     public bool IncludeTimestamp { get; }
+
+    public TimeSpan TimeToLive { get; }
 
     public IReadOnlyList<string> LabelNames { get; }
 

--- a/src/Prometheus.Client/MetricFactory.cs
+++ b/src/Prometheus.Client/MetricFactory.cs
@@ -23,18 +23,18 @@ public class MetricFactory : IMetricFactory
         _registry = registry;
     }
 
-    public ICounter CreateCounter(string name, string help, bool includeTimestamp = false)
+    public ICounter CreateCounter(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        var metric = CreateCounter(name, help, ValueTuple.Create(), includeTimestamp);
+        var metric = CreateCounter(name, help, ValueTuple.Create(), includeTimestamp, timeToLive);
         return metric.Unlabelled;
     }
 
-    public IMetricFamily<ICounter, ValueTuple<string>> CreateCounter(string name, string help, string labelName, bool includeTimestamp = false)
+    public IMetricFamily<ICounter, ValueTuple<string>> CreateCounter(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        return CreateCounter(name, help, ValueTuple.Create(labelName), includeTimestamp);
+        return CreateCounter(name, help, ValueTuple.Create(labelName), includeTimestamp, timeToLive);
     }
 
-    public IMetricFamily<ICounter, TLabels> CreateCounter<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+    public IMetricFamily<ICounter, TLabels> CreateCounter<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
         where TLabels : struct, ITuple, IEquatable<TLabels>
 #else
@@ -44,7 +44,7 @@ public class MetricFactory : IMetricFactory
         var metric = TryGetByName<IMetricFamily<ICounter, TLabels>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp, timeToLive);
             metric = CreateCounterInternal<TLabels>(configuration);
         }
         else
@@ -57,15 +57,20 @@ public class MetricFactory : IMetricFactory
 
     public IMetricFamily<ICounter> CreateCounter(string name, string help, params string[] labelNames)
     {
-        return CreateCounter(name, help, false, labelNames);
+        return CreateCounter(name, help, false, TimeSpan.Zero, labelNames);
     }
 
     public IMetricFamily<ICounter> CreateCounter(string name, string help, bool includeTimestamp = false, params string[] labelNames)
     {
+        return CreateCounter(name, help, includeTimestamp, TimeSpan.Zero, labelNames);
+    }
+
+    public IMetricFamily<ICounter> CreateCounter(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames)
+    {
         var metric = TryGetByName<IMetricFamily<ICounter>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp, timeToLive);
             metric = GetCounterFactory(labelNames?.Length ?? 0)(this, configuration);
         }
         else
@@ -76,18 +81,18 @@ public class MetricFactory : IMetricFactory
         return metric;
     }
 
-    public ICounter<long> CreateCounterInt64(string name, string help, bool includeTimestamp = false)
+    public ICounter<long> CreateCounterInt64(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        var metric = CreateCounterInt64(name, help, ValueTuple.Create(), includeTimestamp);
+        var metric = CreateCounterInt64(name, help, ValueTuple.Create(), includeTimestamp, timeToLive);
         return metric.Unlabelled;
     }
 
-    public IMetricFamily<ICounter<long>, ValueTuple<string>> CreateCounterInt64(string name, string help, string labelName, bool includeTimestamp = false)
+    public IMetricFamily<ICounter<long>, ValueTuple<string>> CreateCounterInt64(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        return CreateCounterInt64(name, help, ValueTuple.Create(labelName), includeTimestamp);
+        return CreateCounterInt64(name, help, ValueTuple.Create(labelName), includeTimestamp, timeToLive);
     }
 
-    public IMetricFamily<ICounter<long>, TLabels> CreateCounterInt64<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+    public IMetricFamily<ICounter<long>, TLabels> CreateCounterInt64<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
         where TLabels : struct, ITuple, IEquatable<TLabels>
 #else
@@ -97,7 +102,7 @@ public class MetricFactory : IMetricFactory
         var metric = TryGetByName<IMetricFamily<ICounter<long>, TLabels>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp, timeToLive);
             metric = CreateCounterInt64Internal<TLabels>(configuration);
         }
         else
@@ -110,15 +115,20 @@ public class MetricFactory : IMetricFactory
 
     public IMetricFamily<ICounter<long>> CreateCounterInt64(string name, string help, params string[] labelNames)
     {
-        return CreateCounterInt64(name, help, false, labelNames);
+        return CreateCounterInt64(name, help, false, TimeSpan.Zero, labelNames);
     }
 
     public IMetricFamily<ICounter<long>> CreateCounterInt64(string name, string help, bool includeTimestamp = false, params string[] labelNames)
     {
+        return CreateCounterInt64(name, help, includeTimestamp, TimeSpan.Zero, labelNames);
+    }
+
+    public IMetricFamily<ICounter<long>> CreateCounterInt64(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames)
+    {
         var metric = TryGetByName<IMetricFamily<ICounter<long>>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp, timeToLive);
             metric = GetCounterInt64Factory(labelNames?.Length ?? 0)(this, configuration);
         }
         else
@@ -129,13 +139,13 @@ public class MetricFactory : IMetricFactory
         return metric;
     }
 
-    public IGauge CreateGauge(string name, string help, bool includeTimestamp = false)
+    public IGauge CreateGauge(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        var metric = CreateGauge(name, help, ValueTuple.Create(), includeTimestamp);
+        var metric = CreateGauge(name, help, ValueTuple.Create(), includeTimestamp, timeToLive);
         return metric.Unlabelled;
     }
 
-    public IMetricFamily<IGauge, TLabels> CreateGauge<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+    public IMetricFamily<IGauge, TLabels> CreateGauge<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
         where TLabels : struct, ITuple, IEquatable<TLabels>
 #else
@@ -145,7 +155,7 @@ public class MetricFactory : IMetricFactory
         var metric = TryGetByName<IMetricFamily<IGauge, TLabels>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp, timeToLive);
             metric = CreateGaugeInternal<TLabels>(configuration);
         }
         else
@@ -158,20 +168,25 @@ public class MetricFactory : IMetricFactory
 
     public IMetricFamily<IGauge> CreateGauge(string name, string help, params string[] labelNames)
     {
-        return CreateGauge(name, help, false, labelNames);
+        return CreateGauge(name, help, false, TimeSpan.Zero, labelNames);
     }
 
-    public IMetricFamily<IGauge, ValueTuple<string>> CreateGauge(string name, string help, string labelName, bool includeTimestamp = false)
+    public IMetricFamily<IGauge, ValueTuple<string>> CreateGauge(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        return CreateGauge(name, help, ValueTuple.Create(labelName), includeTimestamp);
+        return CreateGauge(name, help, ValueTuple.Create(labelName), includeTimestamp, timeToLive);
     }
 
     public IMetricFamily<IGauge> CreateGauge(string name, string help, bool includeTimestamp = false, params string[] labelNames)
     {
+        return CreateGauge(name, help, includeTimestamp, TimeSpan.Zero, labelNames);
+    }
+
+    public IMetricFamily<IGauge> CreateGauge(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames)
+    {
         var metric = TryGetByName<IMetricFamily<IGauge>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp, timeToLive);
             metric = GetGaugeFactory(labelNames?.Length ?? 0)(this, configuration);
         }
         else
@@ -182,18 +197,18 @@ public class MetricFactory : IMetricFactory
         return metric;
     }
 
-    public IGauge<long> CreateGaugeInt64(string name, string help, bool includeTimestamp = false)
+    public IGauge<long> CreateGaugeInt64(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        var metric = CreateGaugeInt64(name, help, ValueTuple.Create(), includeTimestamp);
+        var metric = CreateGaugeInt64(name, help, ValueTuple.Create(), includeTimestamp, timeToLive);
         return metric.Unlabelled;
     }
 
-    public IMetricFamily<IGauge<long>, ValueTuple<string>> CreateGaugeInt64(string name, string help, string labelName, bool includeTimestamp = false)
+    public IMetricFamily<IGauge<long>, ValueTuple<string>> CreateGaugeInt64(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        return CreateGaugeInt64(name, help, ValueTuple.Create(labelName), includeTimestamp);
+        return CreateGaugeInt64(name, help, ValueTuple.Create(labelName), includeTimestamp, timeToLive);
     }
 
-    public IMetricFamily<IGauge<long>, TLabels> CreateGaugeInt64<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+    public IMetricFamily<IGauge<long>, TLabels> CreateGaugeInt64<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
         where TLabels : struct, ITuple, IEquatable<TLabels>
 #else
@@ -203,7 +218,7 @@ public class MetricFactory : IMetricFactory
         var metric = TryGetByName<IMetricFamily<IGauge<long>, TLabels>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp, timeToLive);
             metric = CreateGaugeInt64Internal<TLabels>(configuration);
         }
         else
@@ -216,15 +231,20 @@ public class MetricFactory : IMetricFactory
 
     public IMetricFamily<IGauge<long>> CreateGaugeInt64(string name, string help, params string[] labelNames)
     {
-        return CreateGaugeInt64(name, help, false, labelNames);
+        return CreateGaugeInt64(name, help, false, TimeSpan.Zero, labelNames);
     }
 
     public IMetricFamily<IGauge<long>> CreateGaugeInt64(string name, string help, bool includeTimestamp = false, params string[] labelNames)
     {
+        return CreateGaugeInt64(name, help, includeTimestamp, TimeSpan.Zero, labelNames);
+    }
+
+    public IMetricFamily<IGauge<long>> CreateGaugeInt64(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames)
+    {
         var metric = TryGetByName<IMetricFamily<IGauge<long>>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp, timeToLive);
             metric = GetGaugeInt64Factory(labelNames?.Length ?? 0)(this, configuration);
         }
         else
@@ -235,18 +255,18 @@ public class MetricFactory : IMetricFactory
         return metric;
     }
 
-    public IHistogram CreateHistogram(string name, string help, bool includeTimestamp = false, double[] buckets = null)
+    public IHistogram CreateHistogram(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, double[] buckets = null)
     {
-        var metric = CreateHistogram(name, help, ValueTuple.Create(), includeTimestamp, buckets);
+        var metric = CreateHistogram(name, help, ValueTuple.Create(), includeTimestamp, timeToLive, buckets);
         return metric.Unlabelled;
     }
 
-    public IMetricFamily<IHistogram, ValueTuple<string>> CreateHistogram(string name, string help, string labelName, bool includeTimestamp = false, double[] buckets = null)
+    public IMetricFamily<IHistogram, ValueTuple<string>> CreateHistogram(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default, double[] buckets = null)
     {
-        return CreateHistogram(name, help, ValueTuple.Create(labelName), includeTimestamp, buckets);
+        return CreateHistogram(name, help, ValueTuple.Create(labelName), includeTimestamp, timeToLive, buckets);
     }
 
-    public IMetricFamily<IHistogram, TLabels> CreateHistogram<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, double[] buckets = null)
+    public IMetricFamily<IHistogram, TLabels> CreateHistogram<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default, double[] buckets = null)
 #if NET6_0_OR_GREATER
         where TLabels : struct, ITuple, IEquatable<TLabels>
 #else
@@ -256,7 +276,7 @@ public class MetricFactory : IMetricFactory
         var metric = TryGetByName<IMetricFamily<IHistogram, TLabels>>(name);
         if (metric == null)
         {
-            var configuration = new HistogramConfiguration(name, help, LabelsHelper.ToArray(labelNames), buckets, includeTimestamp);
+            var configuration = new HistogramConfiguration(name, help, LabelsHelper.ToArray(labelNames), buckets, includeTimestamp, timeToLive);
             metric = CreateHistogramInternal<TLabels>(configuration);
         }
         else
@@ -269,25 +289,35 @@ public class MetricFactory : IMetricFactory
 
     public IMetricFamily<IHistogram> CreateHistogram(string name, string help, params string[] labelNames)
     {
-        return CreateHistogram(name, help, false, null, labelNames);
+        return CreateHistogram(name, help, false, TimeSpan.Zero, null, labelNames);
     }
 
     public IMetricFamily<IHistogram> CreateHistogram(string name, string help, bool includeTimestamp = false, params string[] labelNames)
     {
-        return CreateHistogram(name, help, includeTimestamp, null, labelNames);
+        return CreateHistogram(name, help, includeTimestamp, TimeSpan.Zero, null, labelNames);
+    }
+
+    public IMetricFamily<IHistogram> CreateHistogram(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames)
+    {
+        return CreateHistogram(name, help, includeTimestamp, timeToLive, null, labelNames);
     }
 
     public IMetricFamily<IHistogram> CreateHistogram(string name, string help, double[] buckets = null, params string[] labelNames)
     {
-        return CreateHistogram(name, help, false, buckets, labelNames);
+        return CreateHistogram(name, help, false, TimeSpan.Zero, buckets, labelNames);
     }
 
     public IMetricFamily<IHistogram> CreateHistogram(string name, string help, bool includeTimestamp = false, double[] buckets = null, params string[] labelNames)
     {
+        return CreateHistogram(name, help, includeTimestamp, TimeSpan.Zero, buckets, labelNames);
+    }
+
+    public IMetricFamily<IHistogram> CreateHistogram(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, double[] buckets = null, params string[] labelNames)
+    {
         var metric = TryGetByName<IMetricFamily<IHistogram>>(name);
         if (metric == null)
         {
-            var configuration = new HistogramConfiguration(name, help, labelNames, buckets, includeTimestamp);
+            var configuration = new HistogramConfiguration(name, help, labelNames, buckets, includeTimestamp, timeToLive);
             metric = GetHistogramFactory(labelNames?.Length ?? 0)(this, configuration);
         }
         else
@@ -298,18 +328,18 @@ public class MetricFactory : IMetricFactory
         return metric;
     }
 
-    public IUntyped CreateUntyped(string name, string help, bool includeTimestamp = false)
+    public IUntyped CreateUntyped(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        var metric = CreateUntyped(name, help, ValueTuple.Create(), includeTimestamp);
+        var metric = CreateUntyped(name, help, ValueTuple.Create(), includeTimestamp, timeToLive);
         return metric.Unlabelled;
     }
 
-    public IMetricFamily<IUntyped, ValueTuple<string>> CreateUntyped(string name, string help, string labelName, bool includeTimestamp = false)
+    public IMetricFamily<IUntyped, ValueTuple<string>> CreateUntyped(string name, string help, string labelName, bool includeTimestamp = false, TimeSpan timeToLive = default)
     {
-        return CreateUntyped(name, help, ValueTuple.Create(labelName), includeTimestamp);
+        return CreateUntyped(name, help, ValueTuple.Create(labelName), includeTimestamp, timeToLive);
     }
 
-    public IMetricFamily<IUntyped, TLabels> CreateUntyped<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false)
+    public IMetricFamily<IUntyped, TLabels> CreateUntyped<TLabels>(string name, string help, TLabels labelNames, bool includeTimestamp = false, TimeSpan timeToLive = default)
 #if NET6_0_OR_GREATER
         where TLabels : struct, ITuple, IEquatable<TLabels>
 #else
@@ -319,7 +349,7 @@ public class MetricFactory : IMetricFactory
         var metric = TryGetByName<IMetricFamily<IUntyped, TLabels>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp, timeToLive);
             metric = CreateUntypedInternal<TLabels>(configuration);
         }
         else
@@ -332,15 +362,15 @@ public class MetricFactory : IMetricFactory
 
     public IMetricFamily<IUntyped> CreateUntyped(string name, string help, params string[] labelNames)
     {
-        return CreateUntyped(name, help, false, labelNames);
+        return CreateUntyped(name, help, false, TimeSpan.Zero, labelNames);
     }
 
-    public IMetricFamily<IUntyped> CreateUntyped(string name, string help, bool includeTimestamp = false, params string[] labelNames)
+    public IMetricFamily<IUntyped> CreateUntyped(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames)
     {
         var metric = TryGetByName<IMetricFamily<IUntyped>>(name);
         if (metric == null)
         {
-            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp);
+            var configuration = new MetricConfiguration(name, help, labelNames, includeTimestamp, timeToLive);
             metric = GetUntypedFactory(labelNames?.Length ?? 0)(this, configuration);
         }
         else
@@ -353,12 +383,12 @@ public class MetricFactory : IMetricFactory
 
     public IMetricFamily<ISummary> CreateSummary(string name, string help, params string[] labelNames)
     {
-        return CreateSummary(name, help, false, labelNames);
+        return CreateSummary(name, help, false, TimeSpan.Zero, labelNames);
     }
 
-    public IMetricFamily<ISummary> CreateSummary(string name, string help, bool includeTimestamp = false, params string[] labelNames)
+    public IMetricFamily<ISummary> CreateSummary(string name, string help, bool includeTimestamp = false, TimeSpan timeToLive = default, params string[] labelNames)
     {
-        return CreateSummary(name, help, labelNames, includeTimestamp);
+        return CreateSummary(name, help, labelNames, includeTimestamp, timeToLive);
     }
 
     public IMetricFamily<ISummary> CreateSummary(
@@ -370,19 +400,20 @@ public class MetricFactory : IMetricFactory
         int? ageBuckets,
         int? bufCap)
     {
-        return CreateSummary(name, help, labelNames, false, objectives, maxAge, ageBuckets, bufCap);
+        return CreateSummary(name, help, labelNames, false, TimeSpan.Zero, objectives, maxAge, ageBuckets, bufCap);
     }
 
     public ISummary CreateSummary(
         string name,
         string help,
         bool includeTimestamp = false,
+        TimeSpan timeToLive = default,
         IReadOnlyList<QuantileEpsilonPair> objectives = null,
         TimeSpan? maxAge = null,
         int? ageBuckets = null,
         int? bufCap = null)
     {
-        var metric = CreateSummary(name, help, ValueTuple.Create(), includeTimestamp, objectives, maxAge, ageBuckets, bufCap);
+        var metric = CreateSummary(name, help, ValueTuple.Create(), includeTimestamp, timeToLive, objectives, maxAge, ageBuckets, bufCap);
         return metric.Unlabelled;
     }
 
@@ -391,12 +422,13 @@ public class MetricFactory : IMetricFactory
         string help,
         string labelName,
         bool includeTimestamp = false,
+        TimeSpan timeToLive = default,
         IReadOnlyList<QuantileEpsilonPair> objectives = null,
         TimeSpan? maxAge = null,
         int? ageBuckets = null,
         int? bufCap = null)
     {
-        return CreateSummary(name, help, ValueTuple.Create(labelName), includeTimestamp, objectives, maxAge, ageBuckets, bufCap);
+        return CreateSummary(name, help, ValueTuple.Create(labelName), includeTimestamp, timeToLive, objectives, maxAge, ageBuckets, bufCap);
     }
 
     public IMetricFamily<ISummary, TLabels> CreateSummary<TLabels>(
@@ -404,6 +436,7 @@ public class MetricFactory : IMetricFactory
         string help,
         TLabels labelNames,
         bool includeTimestamp = false,
+        TimeSpan timeToLive = default,
         IReadOnlyList<QuantileEpsilonPair> objectives = null,
         TimeSpan? maxAge = null,
         int? ageBuckets = null,
@@ -417,7 +450,7 @@ public class MetricFactory : IMetricFactory
         var metric = TryGetByName<IMetricFamily<ISummary, TLabels>>(name);
         if (metric == null)
         {
-            var configuration = new SummaryConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp, objectives, maxAge, ageBuckets, bufCap);
+            var configuration = new SummaryConfiguration(name, help, LabelsHelper.ToArray(labelNames), includeTimestamp, timeToLive, objectives, maxAge, ageBuckets, bufCap);
             metric = CreateSummaryInternal<TLabels>(configuration);
         }
         else
@@ -433,6 +466,7 @@ public class MetricFactory : IMetricFactory
         string help,
         string[] labelNames,
         bool includeTimestamp,
+        TimeSpan timeToLive = default,
         IReadOnlyList<QuantileEpsilonPair> objectives = null,
         TimeSpan? maxAge = null,
         int? ageBuckets = null,
@@ -441,7 +475,7 @@ public class MetricFactory : IMetricFactory
         var metric = TryGetByName<IMetricFamily<ISummary>>(name);
         if (metric == null)
         {
-            var configuration = new SummaryConfiguration(name, help, labelNames, includeTimestamp, objectives, maxAge, ageBuckets, bufCap);
+            var configuration = new SummaryConfiguration(name, help, labelNames, includeTimestamp, timeToLive, objectives, maxAge, ageBuckets, bufCap);
             metric = GetSummaryFactory(labelNames?.Length ?? 0)(this, configuration);
         }
         else

--- a/src/Prometheus.Client/SummaryConfiguration.cs
+++ b/src/Prometheus.Client/SummaryConfiguration.cs
@@ -36,11 +36,12 @@ public class SummaryConfiguration : MetricConfiguration
         string help,
         string[] labelNames,
         bool includeTimestamp,
+        TimeSpan timeToLive,
         IReadOnlyList<QuantileEpsilonPair> objectives = null,
         TimeSpan? maxAge = null,
         int? ageBuckets = null,
         int? bufCap = null)
-        : base(name, help, labelNames, includeTimestamp)
+        : base(name, help, labelNames, includeTimestamp, timeToLive)
     {
         Objectives = objectives;
         if (Objectives == null || Objectives.Count == 0)

--- a/tests/Prometheus.Client.Benchmarks.Comparison/Histogram/HistogramCreationBenchmarks.cs
+++ b/tests/Prometheus.Client.Benchmarks.Comparison/Histogram/HistogramCreationBenchmarks.cs
@@ -75,7 +75,7 @@ public class HistogramCreationBenchmarks : ComparisonBenchmarkBase
     public void SingleWithSharedLabels()
     {
         for (var i = 0; i < _metricsPerIteration; i++)
-            OurMetricFactory.CreateHistogram("testhistogram", HelpText, false, null, _labelNames);
+            OurMetricFactory.CreateHistogram("testhistogram", HelpText, false, TimeSpan.Zero, null, _labelNames);
     }
 
     [Benchmark(Baseline = true)]

--- a/tests/Prometheus.Client.Benchmarks.Comparison/Histogram/HistogramGeneralUseCaseBenchmarks.cs
+++ b/tests/Prometheus.Client.Benchmarks.Comparison/Histogram/HistogramGeneralUseCaseBenchmarks.cs
@@ -1,3 +1,4 @@
+using System;
 using BenchmarkDotNet.Attributes;
 
 namespace Prometheus.Client.Benchmarks.Comparison.Histogram;
@@ -63,7 +64,7 @@ public class HistogramGeneralUseCaseBenchmarks : ComparisonBenchmarkBase
     {
         for (var i = 0; i < _metricsCount; i++)
         {
-            var histogram = OurMetricFactory.CreateHistogram(_metricNames[i], HelpText, false,"foo", "bar", "baz");
+            var histogram = OurMetricFactory.CreateHistogram(_metricNames[i], HelpText, false, TimeSpan.Zero, "foo", "bar", "baz");
             histogram.Observe(i / 100d);
         }
     }

--- a/tests/Prometheus.Client.Benchmarks.Comparison/Histogram/HistogramSampleBenchmarks.cs
+++ b/tests/Prometheus.Client.Benchmarks.Comparison/Histogram/HistogramSampleBenchmarks.cs
@@ -1,4 +1,5 @@
 extern alias Their;
+using System;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 
@@ -23,7 +24,7 @@ public class HistogramSampleBenchmarks : ComparisonBenchmarkBase
     public void Setup()
     {
         _histogramDefaultBuckets = OurMetricFactory.CreateHistogram("testhistogram1", HelpText);
-        _histogramManyBuckets = OurMetricFactory.CreateHistogram("testhistogram2", HelpText, false, _bucketsMany);
+        _histogramManyBuckets = OurMetricFactory.CreateHistogram("testhistogram2", HelpText, false, TimeSpan.Zero, _bucketsMany);
 
         _theirHistogramDefaultBuckets = TheirMetricFactory.CreateHistogram("testhistogram1", HelpText);
         _theirHistogramManyBuckets = TheirMetricFactory.CreateHistogram("testhistogram2", HelpText, new Their.Prometheus.HistogramConfiguration() { Buckets = _bucketsMany});

--- a/tests/Prometheus.Client.Tests/CounterInt64Tests/CollectionTests.cs
+++ b/tests/Prometheus.Client.Tests/CounterInt64Tests/CollectionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -28,7 +29,7 @@ public class CollectionTests
     public Task Collection()
     {
         return CollectionTestHelper.TestCollectionAsync(factory => {
-            var counter = factory.CreateCounterInt64("test", "with help text", false, "category");
+            var counter = factory.CreateCounterInt64("test", "with help text", false, TimeSpan.Zero, "category");
             counter.Unlabelled.Inc();
             counter.WithLabels("some").Inc(2);
 

--- a/tests/Prometheus.Client.Tests/CounterInt64Tests/FactoryTests.cs
+++ b/tests/Prometheus.Client.Tests/CounterInt64Tests/FactoryTests.cs
@@ -18,6 +18,7 @@ public class FactoryTests
         Assert.Throws<InvalidOperationException>(() => factory.CreateCounterInt64("test_counter", string.Empty, "label1", "testlabel"));
         Assert.Throws<InvalidOperationException>(() => factory.CreateCounterInt64("test_counter", string.Empty, new[] { "label1" }));
         Assert.Throws<InvalidOperationException>(() => factory.CreateCounterInt64("test_counter", string.Empty, "label1", "label2", "label3"));
+        Assert.Throws<InvalidOperationException>(() => factory.CreateCounterInt64("test_counter", string.Empty, false, "label1", "label2", "label3"));
     }
 
     [Fact]

--- a/tests/Prometheus.Client.Tests/CounterInt64Tests/SampleTests.cs
+++ b/tests/Prometheus.Client.Tests/CounterInt64Tests/SampleTests.cs
@@ -61,7 +61,7 @@ public class SampleTests
 
     private CounterInt64 CreateCounter()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new CounterInt64(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/CounterInt64Tests/ThreadingTests.cs
+++ b/tests/Prometheus.Client.Tests/CounterInt64Tests/ThreadingTests.cs
@@ -36,7 +36,7 @@ public class ThreadingTests
 
     private CounterInt64 CreateCounter()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new CounterInt64(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/CounterTests/CollectionTests.cs
+++ b/tests/Prometheus.Client.Tests/CounterTests/CollectionTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -36,5 +38,24 @@ public class CollectionTests
             counter2.Unlabelled.Inc(10.1);
             counter2.WithLabels(("any", "2")).Inc(5.2);
         }, $"{_resourcesNamespace}.CounterTests_Collection.txt");
+    }
+
+    [Fact]
+    public Task RemoveExpiredSerieDueToTtl()
+    {
+        return CollectionTestHelper.TestCollectionAsync(factory => {
+                var counterWithoutTtl = factory.CreateCounter("test", "with help text", "category");
+                counterWithoutTtl.Unlabelled.Inc();
+                counterWithoutTtl.WithLabels("some").Inc(2.1);
+
+                var counterWithTtl = factory.CreateCounter("nextcounter", "with help text", ("group", "type"), timeToLive: TimeSpan.FromSeconds(1));
+                counterWithTtl.WithLabels(("old", "serie")).Inc(8.7);
+
+                Thread.Sleep(1100);
+
+                counterWithTtl.Unlabelled.Inc(10.1);
+                counterWithTtl.WithLabels(("any", "2")).Inc(5.2);
+
+            }, $"{_resourcesNamespace}.CounterTests_Collection.txt");
     }
 }

--- a/tests/Prometheus.Client.Tests/CounterTests/CollectionTests.cs
+++ b/tests/Prometheus.Client.Tests/CounterTests/CollectionTests.cs
@@ -55,7 +55,6 @@ public class CollectionTests
 
                 counterWithTtl.Unlabelled.Inc(10.1);
                 counterWithTtl.WithLabels(("any", "2")).Inc(5.2);
-
             }, $"{_resourcesNamespace}.CounterTests_Collection.txt");
     }
 }

--- a/tests/Prometheus.Client.Tests/CounterTests/SampleTests.cs
+++ b/tests/Prometheus.Client.Tests/CounterTests/SampleTests.cs
@@ -79,7 +79,7 @@ public class SampleTests
 
     private Counter CreateCounter()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new Counter(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/CounterTests/ThreadingTests.cs
+++ b/tests/Prometheus.Client.Tests/CounterTests/ThreadingTests.cs
@@ -36,7 +36,7 @@ public class ThreadingTests
 
     private Counter CreateCounter()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new Counter(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/GaugeInt64Tests/FactoryTests.cs
+++ b/tests/Prometheus.Client.Tests/GaugeInt64Tests/FactoryTests.cs
@@ -22,6 +22,7 @@ public class FactoryTests
         Assert.Throws<InvalidOperationException>(() => _factory.CreateGaugeInt64("test_gauge", string.Empty, "label1", "testlabel"));
         Assert.Throws<InvalidOperationException>(() => _factory.CreateGaugeInt64("test_gauge", string.Empty, new[] { "label1" }));
         Assert.Throws<InvalidOperationException>(() => _factory.CreateGaugeInt64("test_gauge", string.Empty, "label1", "label2", "label3"));
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateGaugeInt64("test_gauge", string.Empty, false, "label1", "label2", "label3"));
     }
 
     [Fact]

--- a/tests/Prometheus.Client.Tests/GaugeInt64Tests/SampleTests.cs
+++ b/tests/Prometheus.Client.Tests/GaugeInt64Tests/SampleTests.cs
@@ -106,7 +106,7 @@ public class SampleTests
 
     private IGauge<long> CreateGauge()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new GaugeInt64(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/GaugeInt64Tests/ThreadingTests.cs
+++ b/tests/Prometheus.Client.Tests/GaugeInt64Tests/ThreadingTests.cs
@@ -36,7 +36,7 @@ public class ThreadingTests
 
     private IGauge<long> CreateGauge()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new GaugeInt64(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/GaugeTests/FactoryTests.cs
+++ b/tests/Prometheus.Client.Tests/GaugeTests/FactoryTests.cs
@@ -22,6 +22,7 @@ public class FactoryTests
         Assert.Throws<InvalidOperationException>(() => _factory.CreateGauge("test_gauge", string.Empty, "label1", "testlabel"));
         Assert.Throws<InvalidOperationException>(() => _factory.CreateGauge("test_gauge", string.Empty, new[] { "label1" }));
         Assert.Throws<InvalidOperationException>(() => _factory.CreateGauge("test_gauge", string.Empty, "label1", "label2", "label3"));
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateGauge("test_gauge", string.Empty, false, "label1", "label2", "label3"));
     }
 
     [Fact]

--- a/tests/Prometheus.Client.Tests/GaugeTests/SampleTests.cs
+++ b/tests/Prometheus.Client.Tests/GaugeTests/SampleTests.cs
@@ -172,7 +172,7 @@ public class SampleTests
 
     private IGauge CreateGauge()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new Gauge(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/GaugeTests/ThreadingTests.cs
+++ b/tests/Prometheus.Client.Tests/GaugeTests/ThreadingTests.cs
@@ -36,7 +36,7 @@ public class ThreadingTests
 
     private IGauge CreateGauge()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new Gauge(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/HistogramTests/CollectionTests.cs
+++ b/tests/Prometheus.Client.Tests/HistogramTests/CollectionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,7 +12,7 @@ public class CollectionTests
     public Task EmptyCollection()
     {
         return CollectionTestHelper.TestCollectionAsync(factory => {
-            factory.CreateHistogram("hist1", "help", false, new[] { 1.0, 2.0, 3.0 });
+            factory.CreateHistogram("hist1", "help", false, TimeSpan.Zero, new[] { 1.0, 2.0, 3.0 });
         }, $"{_resourcesNamespace}.HistogramTests_Empty.txt");
     }
 

--- a/tests/Prometheus.Client.Tests/HistogramTests/FactoryTests.cs
+++ b/tests/Prometheus.Client.Tests/HistogramTests/FactoryTests.cs
@@ -21,6 +21,10 @@ public class FactoryTests
         Assert.Throws<InvalidOperationException>(() => _factory.CreateHistogram("test_histogram", string.Empty, "label1", "testlabel"));
         Assert.Throws<InvalidOperationException>(() => _factory.CreateHistogram("test_histogram", string.Empty, new[] { "label1" }));
         Assert.Throws<InvalidOperationException>(() => _factory.CreateHistogram("test_histogram", string.Empty, "label1", "label2", "label3"));
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateHistogram("test_histogram", string.Empty, false, "label1", "label2", "label3"));
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateHistogram("test_histogram", string.Empty, false, TimeSpan.Zero, "label1", "label2", "label3"));
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateHistogram("test_histogram", string.Empty, false, Array.Empty<double>(), "label1", "label2", "label3"));
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateHistogram("test_histogram", string.Empty, false, TimeSpan.Zero, Array.Empty<double>(), "label1", "label2", "label3"));
     }
 
     [Fact]

--- a/tests/Prometheus.Client.Tests/HistogramTests/HistogramConfigurationTests.cs
+++ b/tests/Prometheus.Client.Tests/HistogramTests/HistogramConfigurationTests.cs
@@ -15,7 +15,8 @@ public class HistogramConfigurationTests
                 string.Empty,
                 new[] {"le"},
                 null,
-                false);
+                false,
+                TimeSpan.Zero);
         }
 
         Assert.Throws<ArgumentException>(Create);
@@ -31,7 +32,8 @@ public class HistogramConfigurationTests
                 string.Empty,
                 Array.Empty<string>(),
                 new double[0],
-                false);
+                false,
+                TimeSpan.Zero);
         }
 
         Assert.Throws<ArgumentException>(Create);
@@ -47,7 +49,8 @@ public class HistogramConfigurationTests
                 string.Empty,
                 Array.Empty<string>(),
                 new [] { 0d, -1d },
-                false);
+                false,
+                TimeSpan.Zero);
         }
 
         Assert.Throws<ArgumentException>(Create);

--- a/tests/Prometheus.Client.Tests/HistogramTests/SampleTests.cs
+++ b/tests/Prometheus.Client.Tests/HistogramTests/SampleTests.cs
@@ -140,7 +140,7 @@ public class SampleTests
 
     private IHistogram CreateHistogram(double[] buckets = null)
     {
-        var config = new HistogramConfiguration("test", string.Empty, Array.Empty<string>(), buckets, false);
+        var config = new HistogramConfiguration("test", string.Empty, Array.Empty<string>(), buckets, false, TimeSpan.Zero);
         return new Histogram(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/HistogramTests/ThreadingTests.cs
+++ b/tests/Prometheus.Client.Tests/HistogramTests/ThreadingTests.cs
@@ -36,7 +36,7 @@ public class ThreadingTests
 
     private IHistogram CreateHistogram(double[] buckets = null)
     {
-        var config = new HistogramConfiguration("test", string.Empty, Array.Empty<string>(), buckets, false);
+        var config = new HistogramConfiguration("test", string.Empty, Array.Empty<string>(), buckets, false, TimeSpan.Zero);
         return new Histogram(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/MetricBaseTests.cs
+++ b/tests/Prometheus.Client.Tests/MetricBaseTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Prometheus.Client.Tests.Mocks;
 using Xunit;
 
@@ -13,7 +14,7 @@ public class MetricBaseTests
     [InlineData(1586594808L, 1586594700L, 1586594700L)]
     public void TimestampTests(long now, long? ts, long expectedTs)
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), true);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), true, TimeSpan.Zero);
 
         var metric = new DummyMetric(config, Array.Empty<string>(), () => DateTimeOffset.FromUnixTimeMilliseconds(now));
         metric.Observe(ts);
@@ -24,7 +25,18 @@ public class MetricBaseTests
     [Fact]
     public void ShouldIgnoreTsIfDisabled()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
+
+        var metric = new DummyMetric(config, Array.Empty<string>(), null);
+        metric.Observe(1586594808);
+
+        Assert.False(metric.Timestamp.HasValue);
+    }
+
+    [Fact]
+    public void ShouldIgnoreTsIfDisabledAndTtlEnabled()
+    {
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.FromSeconds(1));
 
         var metric = new DummyMetric(config, Array.Empty<string>(), null);
         metric.Observe(1586594808);
@@ -35,7 +47,7 @@ public class MetricBaseTests
     [Fact]
     public void ShouldIgnoreTsIfCurrentIsMore()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), true);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), true, TimeSpan.Zero);
 
         var metric = new DummyMetric(config, Array.Empty<string>(), null);
         metric.Observe(1586594808);
@@ -43,5 +55,21 @@ public class MetricBaseTests
         metric.Observe(1586594700);
 
         Assert.Equal(1586594808, metric.Timestamp);
+    }
+
+    [Theory]
+    [InlineData(1587000000L, 1586999999L, false)]
+    [InlineData(1587000000L, 1587000000L, false)]
+    [InlineData(1587000000L, 1587000100L, false)]
+    [InlineData(1587000000L, 1587001000L, true)]
+    [InlineData(1587000000L, 1587050000L, true)]
+    public void ShouldExpireWhenTtlOutlived(long last, long now, bool isExpiredExpected)
+    {
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.FromMilliseconds(500));
+
+        var metric = new DummyMetric(config, Array.Empty<string>(), () => DateTimeOffset.FromUnixTimeMilliseconds(now));
+        metric.Observe(last);
+
+        Assert.Equal(isExpiredExpected, metric.IsExpired());
     }
 }

--- a/tests/Prometheus.Client.Tests/MetricBaseTests.cs
+++ b/tests/Prometheus.Client.Tests/MetricBaseTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using Prometheus.Client.Tests.Mocks;
 using Xunit;
 

--- a/tests/Prometheus.Client.Tests/MetricConfigurationTests.cs
+++ b/tests/Prometheus.Client.Tests/MetricConfigurationTests.cs
@@ -10,7 +10,7 @@ public class MetricConfigurationTests
     [InlineData("")]
     public void ThrowOnInvalidCollectorName(string collectorName)
     {
-        Assert.Throws<ArgumentNullException>(() => new MetricConfiguration(collectorName, string.Empty, null, false));
+        Assert.Throws<ArgumentNullException>(() => new MetricConfiguration(collectorName, string.Empty, null, false, TimeSpan.Zero));
     }
 
     [Theory]
@@ -24,6 +24,6 @@ public class MetricConfigurationTests
     [InlineData("__label")]
     public void ThrowOnInvalidLabels(string label)
     {
-        Assert.Throws<ArgumentException>(() => new MetricConfiguration("test_metric", string.Empty, new[] { label }, false));
+        Assert.Throws<ArgumentException>(() => new MetricConfiguration("test_metric", string.Empty, new[] { label }, false, TimeSpan.Zero));
     }
 }

--- a/tests/Prometheus.Client.Tests/MetricFamilyTests.cs
+++ b/tests/Prometheus.Client.Tests/MetricFamilyTests.cs
@@ -219,7 +219,7 @@ public class MetricFamilyTests
 
     private static IMetricFamily<IDummyMetric> CreateMetricFamily()
     {
-        var config = new MetricConfiguration("dummy_metric", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("dummy_metric", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new MetricFamily<IDummyMetric, DummyMetric, ValueTuple, MetricConfiguration>(
             config, MetricType.Untyped,
             (configuration, list) => new DummyMetric(configuration, list, null));
@@ -227,7 +227,7 @@ public class MetricFamilyTests
 
     private static IMetricFamily<IDummyMetric> CreateMetricFamily(string label1, string label2)
     {
-        var config = new MetricConfiguration("dummy_metric", string.Empty, new[] {label1, label2}, false);
+        var config = new MetricConfiguration("dummy_metric", string.Empty, new[] {label1, label2}, false, TimeSpan.Zero);
         return new MetricFamily<IDummyMetric, DummyMetric, (string, string), MetricConfiguration>(
             config, MetricType.Untyped,
             (configuration, list) => new DummyMetric(configuration, list, null));
@@ -240,7 +240,7 @@ public class MetricFamilyTests
         where TLabels : struct, IEquatable<TLabels>
 #endif
     {
-        var config = new MetricConfiguration("dummy_metric", string.Empty, LabelsHelper.ToArray(labels), false);
+        var config = new MetricConfiguration("dummy_metric", string.Empty, LabelsHelper.ToArray(labels), false, TimeSpan.Zero);
         return new MetricFamily<IDummyMetric, DummyMetric, TLabels, MetricConfiguration>(
             config, MetricType.Untyped,
             (configuration, list) => new DummyMetric(configuration, list, null));

--- a/tests/Prometheus.Client.Tests/SummaryTests/FactoryTests.cs
+++ b/tests/Prometheus.Client.Tests/SummaryTests/FactoryTests.cs
@@ -14,6 +14,17 @@ public class FactoryTests
     }
 
     [Fact]
+    public void ThrowOnNameConflict_Strings()
+    {
+        _factory.CreateHistogram("test_histogram", string.Empty, "label1", "label2");
+
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateSummary("test_histogram", string.Empty, "label1", "testlabel"));
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateSummary("test_histogram", string.Empty, new[] { "label1" }));
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateSummary("test_histogram", string.Empty, "label1", "label2", "label3"));
+        Assert.Throws<InvalidOperationException>(() => _factory.CreateSummary("test_histogram", string.Empty, false, TimeSpan.Zero, "label1", "label2", "label3"));
+    }
+
+    [Fact]
     public void SingleLabel_ConvertToTuple()
     {
         var metric = _factory.CreateSummary("metricname", "help", "label");

--- a/tests/Prometheus.Client.Tests/SummaryTests/SampleTests.cs
+++ b/tests/Prometheus.Client.Tests/SummaryTests/SampleTests.cs
@@ -22,7 +22,7 @@ public class SampleTests
 
     private ISummary CreateSummary()
     {
-        var config = new SummaryConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new SummaryConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new Summary(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/SummaryTests/SummaryTests.cs
+++ b/tests/Prometheus.Client.Tests/SummaryTests/SummaryTests.cs
@@ -20,7 +20,7 @@ public class SummaryTests
         int concLevel = (n % 5) + 1;
         int total = mutations * concLevel;
 
-        var sum = new Summary(new SummaryConfiguration("test_summary", "helpless", Array.Empty<string>(), false), Array.Empty<string>());
+        var sum = new Summary(new SummaryConfiguration("test_summary", "helpless", Array.Empty<string>(), false, TimeSpan.Zero), Array.Empty<string>());
 
         var allVars = new double[total];
         double sampleSum = 0;
@@ -141,7 +141,7 @@ public class SummaryTests
     {
         var baseTime = new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         DateTimeOffset currentTime = baseTime;
-        var summaryConfig = new SummaryConfiguration("test_summary", "helpless", Array.Empty<string>(), false,
+        var summaryConfig = new SummaryConfiguration("test_summary", "helpless", Array.Empty<string>(), false, TimeSpan.Zero,
             new List<QuantileEpsilonPair> { new QuantileEpsilonPair(0.1d, 0.001d) }, TimeSpan.FromSeconds(100), 10);
         var child = new Summary(summaryConfig, Array.Empty<string>(), () => currentTime);
         var values = new double[summaryConfig.Objectives.Count];

--- a/tests/Prometheus.Client.Tests/SummaryTests/ThreadingTests.cs
+++ b/tests/Prometheus.Client.Tests/SummaryTests/ThreadingTests.cs
@@ -37,7 +37,7 @@ public class ThreadingTests
 
     private Summary CreateSummary()
     {
-        var config = new SummaryConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new SummaryConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new Summary(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/UntypedTests/SampleTests.cs
+++ b/tests/Prometheus.Client.Tests/UntypedTests/SampleTests.cs
@@ -31,7 +31,7 @@ public class SampleTests
 
     private IUntyped CreateUntyped()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new Untyped(config, Array.Empty<string>());
     }
 }

--- a/tests/Prometheus.Client.Tests/UntypedTests/ThreadingTests.cs
+++ b/tests/Prometheus.Client.Tests/UntypedTests/ThreadingTests.cs
@@ -36,7 +36,7 @@ public class ThreadingTests
 
     private IUntyped CreateUntyped()
     {
-        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false);
+        var config = new MetricConfiguration("test", string.Empty, Array.Empty<string>(), false, TimeSpan.Zero);
         return new Untyped(config, Array.Empty<string>());
     }
 }


### PR DESCRIPTION
# Context

Having a time-to-live for a given serie (a given set of labels values) can be beneficial to avoid issues such as cardinality explosion for long lasting workloads and limit the occurence of "flat" lines when plotting time series data.

The alternate prometheus C# client library [has this feature ](https://github.com/prometheus-net/prometheus-net?tab=readme-ov-file#deleting-metrics), named as a "managed lifetime". 

# Solution

This pull request present a solution to implement such a time-to-live mecanism. It leverages the existing internal timestamp logic to keep track of the last timestamp of a serie. When the `TimeToLive` configuration is set to a `TimeSpan` greated then `TimeSpan.Zero` (`default` value), timestamps will be computed, even though exposing timestamps is not enabled in the configuration.

When collecting, the lifespan of a metric is checked and if the serie has expired, we delete that serie. Same goes for unlabelled, with the exception that we reset the `Lazy<T>` instead, resulting in unlabelled values to no longer be collected, unless it gets incremented again later.

## Performance

I don't think this PR has any effect on performance when `TimeToLive` is not used. If used, the performant hit is the same as to using timestamps.

## API Changes

This PR does introduce a new argument for several `IMetricFactory` methods. The new argument is not always on the last position, as I tried to keep it next to `includeTimestamp`, and it sometimes is followed by by `buckets` or `labelNames` arguments. I deduplicated a few methods to keep `includeTimestamp` without `timeToLive` to increase backward compatibility, but it wasn't always possible. As such, this MR does introduces some breaking changes regarding theses signatures.

## Testing

A new test `MetricBaseTests.ShouldExpireWhenTtlOutlived` was added to cover `IsExpired` logic. 
Another test `CounterTests.RemoveExpiredSerieDueToTtl` was added to cover the feature at an higher level, but I am not sure if it should be deduplicated to other metric types as well. This package code coverage is above what I am generally used to.
 